### PR TITLE
add raw log and blueocean pipeline job log urls

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -23,6 +23,8 @@ public class Constants {
   public static final String OPENSHIFT_ANNOTATIONS_BUILD_NUMBER = "openshift.io/build.number";
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI = "openshift.io/jenkins-build-uri";
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
+  public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
+  public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
 
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
   public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";


### PR DESCRIPTION
@bparees @spadgett @jwforres per our recent email thread, and in a response to an ask from @smarterclayton that if blue ocean is stable enough (which I think is yes at this point), some additional log annotations on the build object from the sync plugin .... ptal