### PR TITLE
Modified credentialsId to never return null

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -1,11 +1,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.Credentials;
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
-import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.*;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
@@ -25,12 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static hudson.Util.fixNull;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_DATA_PASSWORD;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_DATA_USERNAME;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_TYPE_BASICAUTH;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_TYPE_OPAQUE;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_SECRETS_TYPE_SSH;
+import static io.fabric8.jenkins.openshiftsync.Constants.*;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -65,18 +56,25 @@ public class CredentialsUtils {
     return id;
   }
 
+  // getCurrentToken returns the ServiceAccount token currently selected by the user. A return value of empty string
+  // implies no token is configured.
   public static String getCurrentToken() {
+    String credentialsId = GlobalPluginConfiguration.get().getCredentialsId();
+    if(credentialsId.equals("")) {
+      return "";
+    }
+
     OpenShiftToken token = CredentialsMatchers.firstOrNull(
             CredentialsProvider.lookupCredentials(
                     OpenShiftToken.class,
                     Jenkins.getActiveInstance(),
                     ACL.SYSTEM,
-                    Collections.<DomainRequirement> emptyList()
+                    Collections.<DomainRequirement>emptyList()
             ),
-            CredentialsMatchers.withId(GlobalPluginConfiguration.get().getCredentialsId())
-            );
+            CredentialsMatchers.withId(credentialsId)
+    );
 
-    if( token != null ) {
+    if (token != null) {
       return token.getToken();
     }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -103,8 +103,9 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
     this.server = server;
   }
 
+  // When Jenkins is reset, credentialsId is strangely set to null. However, credentialsId has no reason to be null.
   public String getCredentialsId() {
-    return credentialsId;
+    return credentialsId == null ? "" : credentialsId;
   }
 
   public void setCredentialsId(String credentialsId) {


### PR DESCRIPTION
Fixes #132 

For getCredentialsId, we need to do a null check there. Somehow, the String is getting set to null, although not through its setter. This only happens when it is already emptystring.

@gabemontero @openshift/devex ptal?