### PR TITLE
Resolves https://github.com/openshift/jenkins-sync-plugin/issues/131

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ crashlytics-build.properties
 
 # Created by .ignore support plugin (hsz.mobi)
 work/
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,33 @@
       <version>2.21</version>
     </dependency>
 
+    <!-- for multi-branch job detection -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.10</version>
+    </dependency>
+
+    <!--
+        These dependencies come in from the workflow-multibranch dependency:
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.0.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+      <version>2.0.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <version>5.18</version>
+    </dependency>
+
+    
     <!-- testing -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -245,6 +272,34 @@
       <scope>test</scope>
     </dependency>
 
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-organization-folder</artifactId>
+      <version>1.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-github-lib</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
+      <version>2.0.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.coravy.hudson.plugins.github</groupId>
+      <artifactId>github</artifactId>
+      <version>1.26.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.jenkins.openshiftsync;
+
+/**
+ */
+public class Annotations {
+    public static final String JENKINS_JOB_PATH = "jenkins.openshift.org/job-path";
+    public static final String GENERATED_BY = "jenkins.openshift.org/generated-by";
+    public static final String DISABLE_SYNC_CREATE_ON = "jenkins.openshift.org/disable-sync-create-on";
+}

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -18,7 +18,7 @@ package io.fabric8.jenkins.openshiftsync;
 /**
  */
 public class Annotations {
-    public static final String JENKINS_JOB_PATH = "jenkins.openshift.org/job-path";
-    public static final String GENERATED_BY = "jenkins.openshift.org/generated-by";
-    public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.org/disable-sync-create";
+    public static final String JENKINS_JOB_PATH = "jenkins.openshift.io/job-path";
+    public static final String GENERATED_BY = "jenkins.openshift.io/generated-by";
+    public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -18,7 +18,7 @@ package io.fabric8.jenkins.openshiftsync;
 /**
  */
 public class Annotations {
-    public static final String JENKINS_JOB_PATH = "jenkins.openshift.io/job-path";
-    public static final String GENERATED_BY = "jenkins.openshift.io/generated-by";
-    public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
+	public static final String JENKINS_JOB_PATH = "jenkins.openshift.io/job-path";
+	public static final String GENERATED_BY = "jenkins.openshift.io/generated-by";
+	public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -20,5 +20,5 @@ package io.fabric8.jenkins.openshiftsync;
 public class Annotations {
     public static final String JENKINS_JOB_PATH = "jenkins.openshift.org/job-path";
     public static final String GENERATED_BY = "jenkins.openshift.org/generated-by";
-    public static final String DISABLE_SYNC_CREATE_ON = "jenkins.openshift.org/disable-sync-create-on";
+    public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.org/disable-sync-create";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -27,6 +27,7 @@ import io.fabric8.openshift.api.model.BuildSource;
 import io.fabric8.openshift.api.model.BuildStrategy;
 import io.fabric8.openshift.api.model.GitBuildSource;
 import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
+import jenkins.branch.Branch;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
@@ -34,6 +35,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 
 import java.io.File;
 import java.io.IOException;
@@ -135,40 +137,15 @@ public class BuildConfigToJobMapper {
       CpsScmFlowDefinition cpsScmFlowDefinition = (CpsScmFlowDefinition) definition;
       String scriptPath = cpsScmFlowDefinition.getScriptPath();
       if (scriptPath != null && scriptPath.trim().length() > 0) {
-        String bcContextDir = buildConfig.getSpec().getSource().getContextDir();
+        BuildSource source = getOrCreateBuildSource(spec);
+        String bcContextDir = source.getContextDir();
         if (StringUtils.isNotBlank(bcContextDir) && scriptPath.startsWith(bcContextDir)) {
           scriptPath = scriptPath.replaceFirst("^" + bcContextDir + "/?", "");
         }
-
         jenkinsPipelineStrategy.setJenkinsfilePath(scriptPath);
-
         SCM scm = cpsScmFlowDefinition.getScm();
         if (scm instanceof GitSCM) {
-          GitSCM gitSCM = (GitSCM) scm;
-          List<RemoteConfig> repositories = gitSCM.getRepositories();
-          if (repositories != null && repositories.size() > 0) {
-            RemoteConfig remoteConfig = repositories.get(0);
-            List<URIish> urIs = remoteConfig.getURIs();
-            if (urIs != null && urIs.size() > 0) {
-              URIish urIish = urIs.get(0);
-              String gitUrl = urIish.toString();
-              if (gitUrl != null && gitUrl.length() > 0) {
-                String ref = null;
-                List<BranchSpec> branches = gitSCM.getBranches();
-                if (branches != null && branches.size() > 0) {
-                  BranchSpec branchSpec = branches.get(0);
-                  String branch = branchSpec.getName();
-                  while (branch.startsWith("*") || branch.startsWith("/")) {
-                    branch = branch.substring(1);
-                  }
-                  if (!branch.isEmpty()) {
-                    ref = branch;
-                  }
-                }
-                OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
-              }
-            }
-          }
+          populateFromGitSCM(buildConfig, source, (GitSCM) scm, null);
         }
         return true;
       }
@@ -185,7 +162,66 @@ public class BuildConfigToJobMapper {
       return false;
     }
 
+    // support multi-branch or github organisation jobs
+    BranchJobProperty property = job.getProperty(BranchJobProperty.class);
+    if (property != null) {
+      Branch branch = property.getBranch();
+      if (branch != null) {
+        String ref = branch.getName();
+        SCM scm = branch.getScm();
+        BuildSource source = getOrCreateBuildSource(spec);
+        if (scm instanceof GitSCM) {
+          if (populateFromGitSCM(buildConfig, source, (GitSCM) scm, ref)) {
+            if (StringUtils.isEmpty(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+              jenkinsPipelineStrategy.setJenkinsfilePath("Jenkinsfile");
+            }
+            return true;
+          }
+        }
+      }
+    }
+    
     LOGGER.warning("Cannot update BuildConfig " + namespaceName + " as the definition is of class " + (definition == null ? "null" : definition.getClass().getName()));
     return false;
+  }
+
+  private static boolean populateFromGitSCM(BuildConfig buildConfig, BuildSource source, GitSCM gitSCM, String ref) {
+    source.setType("Git");
+    List<RemoteConfig> repositories = gitSCM.getRepositories();
+    if (repositories != null && repositories.size() > 0) {
+      RemoteConfig remoteConfig = repositories.get(0);
+      List<URIish> urIs = remoteConfig.getURIs();
+      if (urIs != null && urIs.size() > 0) {
+        URIish urIish = urIs.get(0);
+        String gitUrl = urIish.toString();
+        if (gitUrl != null && gitUrl.length() > 0) {
+          if (StringUtils.isEmpty(ref)) {
+            List<BranchSpec> branches = gitSCM.getBranches();
+            if (branches != null && branches.size() > 0) {
+              BranchSpec branchSpec = branches.get(0);
+              String branch = branchSpec.getName();
+              while (branch.startsWith("*") || branch.startsWith("/")) {
+                branch = branch.substring(1);
+              }
+              if (!branch.isEmpty()) {
+                ref = branch;
+              }
+            }
+          }
+          OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static BuildSource getOrCreateBuildSource(BuildConfigSpec spec) {
+    BuildSource source = spec.getSource();
+    if (source == null) {
+      source = new BuildSource();
+      spec.setSource(source);
+    }
+    return source;
   }
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -50,200 +50,191 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 public class BuildConfigToJobMapper {
-    public static final String JENKINS_PIPELINE_BUILD_STRATEGY = "JenkinsPipeline";
-    public static final String DEFAULT_JENKINS_FILEPATH = "Jenkinsfile";
-    private static final Logger LOGGER = Logger
-            .getLogger(BuildConfigToJobMapper.class.getName());
+	public static final String JENKINS_PIPELINE_BUILD_STRATEGY = "JenkinsPipeline";
+	public static final String DEFAULT_JENKINS_FILEPATH = "Jenkinsfile";
+	private static final Logger LOGGER = Logger.getLogger(BuildConfigToJobMapper.class.getName());
 
-    public static FlowDefinition mapBuildConfigToFlow(BuildConfig bc)
-            throws IOException {
-        if (!OpenShiftUtils.isPipelineStrategyBuildConfig(bc)) {
-            return null;
-        }
+	public static FlowDefinition mapBuildConfigToFlow(BuildConfig bc) throws IOException {
+		if (!OpenShiftUtils.isPipelineStrategyBuildConfig(bc)) {
+			return null;
+		}
 
-        BuildConfigSpec spec = bc.getSpec();
-        BuildSource source = null;
-        String jenkinsfile = null;
-        String jenkinsfilePath = null;
-        if (spec != null) {
-            source = spec.getSource();
-            BuildStrategy strategy = spec.getStrategy();
-            if (strategy != null) {
-                JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy
-                        .getJenkinsPipelineStrategy();
-                if (jenkinsPipelineStrategy != null) {
-                    jenkinsfile = jenkinsPipelineStrategy.getJenkinsfile();
-                    jenkinsfilePath = jenkinsPipelineStrategy
-                            .getJenkinsfilePath();
-                }
-            }
-        }
-        if (jenkinsfile == null) {
-            // Is this a Jenkinsfile from Git SCM?
-            if (source != null && source.getGit() != null
-                    && source.getGit().getUri() != null) {
-                if (jenkinsfilePath == null) {
-                    jenkinsfilePath = DEFAULT_JENKINS_FILEPATH;
-                }
-                if (!isEmpty(source.getContextDir())) {
-                    jenkinsfilePath = new File(source.getContextDir(),
-                            jenkinsfilePath).getPath();
-                }
-                GitBuildSource gitSource = source.getGit();
-                String branchRef = gitSource.getRef();
-                List<BranchSpec> branchSpecs = Collections.emptyList();
-                if (isNotBlank(branchRef)) {
-                    branchSpecs = Collections.singletonList(new BranchSpec(
-                            branchRef));
-                }
-                String credentialsId = updateSourceCredentials(bc);
-                GitSCM scm = new GitSCM(
-                        Collections.singletonList(new UserRemoteConfig(
-                                gitSource.getUri(), null, null, credentialsId)),
-                        branchSpecs, false, Collections
-                                .<SubmoduleConfig> emptyList(), null, null,
-                        Collections.<GitSCMExtension> emptyList());
-                return new CpsScmFlowDefinition(scm, jenkinsfilePath);
-            } else {
-                LOGGER.warning("BuildConfig does not contain source repository information - cannot map BuildConfig to Jenkins job");
-                return null;
-            }
-        } else {
-            return new CpsFlowDefinition(jenkinsfile, true);
-        }
-    }
+		BuildConfigSpec spec = bc.getSpec();
+		BuildSource source = null;
+		String jenkinsfile = null;
+		String jenkinsfilePath = null;
+		if (spec != null) {
+			source = spec.getSource();
+			BuildStrategy strategy = spec.getStrategy();
+			if (strategy != null) {
+				JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+				if (jenkinsPipelineStrategy != null) {
+					jenkinsfile = jenkinsPipelineStrategy.getJenkinsfile();
+					jenkinsfilePath = jenkinsPipelineStrategy.getJenkinsfilePath();
+				}
+			}
+		}
+		if (jenkinsfile == null) {
+			// Is this a Jenkinsfile from Git SCM?
+			if (source != null && source.getGit() != null && source.getGit().getUri() != null) {
+				if (jenkinsfilePath == null) {
+					jenkinsfilePath = DEFAULT_JENKINS_FILEPATH;
+				}
+				if (!isEmpty(source.getContextDir())) {
+					jenkinsfilePath = new File(source.getContextDir(), jenkinsfilePath).getPath();
+				}
+				GitBuildSource gitSource = source.getGit();
+				String branchRef = gitSource.getRef();
+				List<BranchSpec> branchSpecs = Collections.emptyList();
+				if (isNotBlank(branchRef)) {
+					branchSpecs = Collections.singletonList(new BranchSpec(branchRef));
+				}
+				String credentialsId = updateSourceCredentials(bc);
+				GitSCM scm = new GitSCM(
+						Collections.singletonList(new UserRemoteConfig(gitSource.getUri(), null, null, credentialsId)),
+						branchSpecs, false, Collections.<SubmoduleConfig>emptyList(), null, null,
+						Collections.<GitSCMExtension>emptyList());
+				return new CpsScmFlowDefinition(scm, jenkinsfilePath);
+			} else {
+				LOGGER.warning("BuildConfig does not contain source repository information - "
+						+ "cannot map BuildConfig to Jenkins job");
+				return null;
+			}
+		} else {
+			return new CpsFlowDefinition(jenkinsfile, true);
+		}
+	}
 
-    /**
-     * Updates the {@link BuildConfig} if the Jenkins {@link WorkflowJob}
-     * changes
-     *
-     * @param job
-     *            the job thats been updated via Jenkins
-     * @param buildConfig
-     *            the OpenShift BuildConfig to update
-     * @return true if the BuildConfig was changed
-     */
-    public static boolean updateBuildConfigFromJob(WorkflowJob job,
-            BuildConfig buildConfig) {
-        NamespaceName namespaceName = NamespaceName.create(buildConfig);
-        JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = null;
-        BuildConfigSpec spec = buildConfig.getSpec();
-        if (spec != null) {
-            BuildStrategy strategy = spec.getStrategy();
-            if (strategy != null) {
-                jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
-            }
-        }
+	/**
+	 * Updates the {@link BuildConfig} if the Jenkins {@link WorkflowJob} changes
+	 *
+	 * @param job
+	 *            the job thats been updated via Jenkins
+	 * @param buildConfig
+	 *            the OpenShift BuildConfig to update
+	 * @return true if the BuildConfig was changed
+	 */
+	public static boolean updateBuildConfigFromJob(WorkflowJob job, BuildConfig buildConfig) {
+		NamespaceName namespaceName = NamespaceName.create(buildConfig);
+		JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = null;
+		BuildConfigSpec spec = buildConfig.getSpec();
+		if (spec != null) {
+			BuildStrategy strategy = spec.getStrategy();
+			if (strategy != null) {
+				jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+			}
+		}
 
-        if (jenkinsPipelineStrategy == null) {
-            LOGGER.warning("No jenkinsPipelineStrategy available in the BuildConfig "
-                    + namespaceName);
-            return false;
-        }
+		if (jenkinsPipelineStrategy == null) {
+			LOGGER.warning("No jenkinsPipelineStrategy available in the BuildConfig " + namespaceName);
+			return false;
+		}
 
-        FlowDefinition definition = job.getDefinition();
-        if (definition instanceof CpsScmFlowDefinition) {
-          CpsScmFlowDefinition cpsScmFlowDefinition = (CpsScmFlowDefinition) definition;
-          String scriptPath = cpsScmFlowDefinition.getScriptPath();
-          if (scriptPath != null && scriptPath.trim().length() > 0) {
-            boolean rc = false;
-            BuildSource source = getOrCreateBuildSource(spec);
-            String bcContextDir = source.getContextDir();
-            if (StringUtils.isNotBlank(bcContextDir) && scriptPath.startsWith(bcContextDir)) {
-              scriptPath = scriptPath.replaceFirst("^" + bcContextDir + "/?", "");
-              }
+		FlowDefinition definition = job.getDefinition();
+		if (definition instanceof CpsScmFlowDefinition) {
+			CpsScmFlowDefinition cpsScmFlowDefinition = (CpsScmFlowDefinition) definition;
+			String scriptPath = cpsScmFlowDefinition.getScriptPath();
+			if (scriptPath != null && scriptPath.trim().length() > 0) {
+				boolean rc = false;
+				BuildSource source = getOrCreateBuildSource(spec);
+				String bcContextDir = source.getContextDir();
+				if (StringUtils.isNotBlank(bcContextDir) && scriptPath.startsWith(bcContextDir)) {
+					scriptPath = scriptPath.replaceFirst("^" + bcContextDir + "/?", "");
+				}
 
-              if (!scriptPath.equals(jenkinsPipelineStrategy
-                      .getJenkinsfilePath())) {
-                  LOGGER.log(Level.FINE, "updating bc " + namespaceName
-                          + " jenkinsfile path to " + scriptPath + " from ");
-                  rc = true;
-                  jenkinsPipelineStrategy.setJenkinsfilePath(scriptPath);
-              }
+				if (!scriptPath.equals(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+					LOGGER.log(Level.FINE,
+							"updating bc " + namespaceName + " jenkinsfile path to " + scriptPath + " from ");
+					rc = true;
+					jenkinsPipelineStrategy.setJenkinsfilePath(scriptPath);
+				}
 
-              SCM scm = cpsScmFlowDefinition.getScm();
-              if (scm instanceof GitSCM) {
-                populateFromGitSCM(buildConfig, source, (GitSCM) scm, null);
-                LOGGER.log(Level.FINE, "updating bc " + namespaceName );
-                rc = true;
-              }
-              return rc;
-            }
-          return false;
-        }
+				SCM scm = cpsScmFlowDefinition.getScm();
+				if (scm instanceof GitSCM) {
+					populateFromGitSCM(buildConfig, source, (GitSCM) scm, null);
+					LOGGER.log(Level.FINE, "updating bc " + namespaceName);
+					rc = true;
+				}
+				return rc;
+			}
+			return false;
+		}
 
-    if (definition instanceof CpsFlowDefinition) {
-      CpsFlowDefinition cpsFlowDefinition = (CpsFlowDefinition) definition;
-      String jenkinsfile = cpsFlowDefinition.getScript();
-      if (jenkinsfile != null && jenkinsfile.trim().length() > 0 && !jenkinsfile.equals(jenkinsPipelineStrategy.getJenkinsfile())) {
-          LOGGER.log(Level.FINE, "updating bc " + namespaceName + " jenkinsfile to " + jenkinsfile + " where old jenkinsfile was " + jenkinsPipelineStrategy.getJenkinsfile());
-        jenkinsPipelineStrategy.setJenkinsfile(jenkinsfile);
-        return true;
-      }
+		if (definition instanceof CpsFlowDefinition) {
+			CpsFlowDefinition cpsFlowDefinition = (CpsFlowDefinition) definition;
+			String jenkinsfile = cpsFlowDefinition.getScript();
+			if (jenkinsfile != null && jenkinsfile.trim().length() > 0
+					&& !jenkinsfile.equals(jenkinsPipelineStrategy.getJenkinsfile())) {
+				LOGGER.log(Level.FINE, "updating bc " + namespaceName + " jenkinsfile to " + jenkinsfile
+						+ " where old jenkinsfile was " + jenkinsPipelineStrategy.getJenkinsfile());
+				jenkinsPipelineStrategy.setJenkinsfile(jenkinsfile);
+				return true;
+			}
 
-      return false;
-    }
+			return false;
+		}
 
-    // support multi-branch or github organization jobs
-    BranchJobProperty property = job.getProperty(BranchJobProperty.class);
-    if (property != null) {
-      Branch branch = property.getBranch();
-      if (branch != null) {
-        String ref = branch.getName();
-        SCM scm = branch.getScm();
-        BuildSource source = getOrCreateBuildSource(spec);
-        if (scm instanceof GitSCM) {
-          if (populateFromGitSCM(buildConfig, source, (GitSCM) scm, ref)) {
-            if (StringUtils.isEmpty(jenkinsPipelineStrategy.getJenkinsfilePath())) {
-              jenkinsPipelineStrategy.setJenkinsfilePath("Jenkinsfile");
-            }
-            return true;
-          }
-        }
-      }
-    }
-    
-    LOGGER.warning("Cannot update BuildConfig " + namespaceName + " as the definition is of class " + (definition == null ? "null" : definition.getClass().getName()));
-    return false;
-  }
+		// support multi-branch or github organization jobs
+		BranchJobProperty property = job.getProperty(BranchJobProperty.class);
+		if (property != null) {
+			Branch branch = property.getBranch();
+			if (branch != null) {
+				String ref = branch.getName();
+				SCM scm = branch.getScm();
+				BuildSource source = getOrCreateBuildSource(spec);
+				if (scm instanceof GitSCM) {
+					if (populateFromGitSCM(buildConfig, source, (GitSCM) scm, ref)) {
+						if (StringUtils.isEmpty(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+							jenkinsPipelineStrategy.setJenkinsfilePath("Jenkinsfile");
+						}
+						return true;
+					}
+				}
+			}
+		}
 
-  private static boolean populateFromGitSCM(BuildConfig buildConfig, BuildSource source, GitSCM gitSCM, String ref) {
-    source.setType("Git");
-    List<RemoteConfig> repositories = gitSCM.getRepositories();
-    if (repositories != null && repositories.size() > 0) {
-      RemoteConfig remoteConfig = repositories.get(0);
-      List<URIish> urIs = remoteConfig.getURIs();
-      if (urIs != null && urIs.size() > 0) {
-        URIish urIish = urIs.get(0);
-        String gitUrl = urIish.toString();
-        if (gitUrl != null && gitUrl.length() > 0) {
-          if (StringUtils.isEmpty(ref)) {
-            List<BranchSpec> branches = gitSCM.getBranches();
-            if (branches != null && branches.size() > 0) {
-              BranchSpec branchSpec = branches.get(0);
-              String branch = branchSpec.getName();
-              while (branch.startsWith("*") || branch.startsWith("/")) {
-                branch = branch.substring(1);
-              }
-              if (!branch.isEmpty()) {
-                ref = branch;
-              }
-            }
-          }
-          OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
-          return true;
-        }
-      }
-    }
-    return false;
-  }
+		LOGGER.warning("Cannot update BuildConfig " + namespaceName + " as the definition is of class "
+				+ (definition == null ? "null" : definition.getClass().getName()));
+		return false;
+	}
 
-  private static BuildSource getOrCreateBuildSource(BuildConfigSpec spec) {
-    BuildSource source = spec.getSource();
-    if (source == null) {
-      source = new BuildSource();
-      spec.setSource(source);
-    }
-    return source;
-  }
+	private static boolean populateFromGitSCM(BuildConfig buildConfig, BuildSource source, GitSCM gitSCM, String ref) {
+		source.setType("Git");
+		List<RemoteConfig> repositories = gitSCM.getRepositories();
+		if (repositories != null && repositories.size() > 0) {
+			RemoteConfig remoteConfig = repositories.get(0);
+			List<URIish> urIs = remoteConfig.getURIs();
+			if (urIs != null && urIs.size() > 0) {
+				URIish urIish = urIs.get(0);
+				String gitUrl = urIish.toString();
+				if (gitUrl != null && gitUrl.length() > 0) {
+					if (StringUtils.isEmpty(ref)) {
+						List<BranchSpec> branches = gitSCM.getBranches();
+						if (branches != null && branches.size() > 0) {
+							BranchSpec branchSpec = branches.get(0);
+							String branch = branchSpec.getName();
+							while (branch.startsWith("*") || branch.startsWith("/")) {
+								branch = branch.substring(1);
+							}
+							if (!branch.isEmpty()) {
+								ref = branch;
+							}
+						}
+					}
+					OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static BuildSource getOrCreateBuildSource(BuildConfigSpec spec) {
+		BuildSource source = spec.getSource();
+		if (source == null) {
+			source = new BuildSource();
+			spec.setSource(source);
+		}
+		return source;
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -175,7 +175,7 @@ public class BuildConfigToJobMapper {
       return false;
     }
 
-    // support multi-branch or github organisation jobs
+    // support multi-branch or github organization jobs
     BranchJobProperty property = job.getProperty(BranchJobProperty.class);
     if (property != null) {
       Branch branch = property.getBranch();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static io.fabric8.jenkins.openshiftsync.Annotations.DISABLE_SYNC_CREATE_ON;
+import static io.fabric8.jenkins.openshiftsync.Annotations.DISABLE_SYNC_CREATE;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfig;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.initializeBuildConfigToJobMap;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.putJobWithBuildConfig;
@@ -197,9 +197,9 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
           }
           boolean newJob = job == null;
           if (newJob) {
-            String disableOn = getAnnotation(buildConfig, DISABLE_SYNC_CREATE_ON);
+            String disableOn = getAnnotation(buildConfig, DISABLE_SYNC_CREATE);
             if (disableOn != null && disableOn.equalsIgnoreCase("jenkins")) {
-              logger.fine("Not creating missing jenkins job " + jobFullName + " due to annotation: " + DISABLE_SYNC_CREATE_ON);
+              logger.fine("Not creating missing jenkins job " + jobFullName + " due to annotation: " + DISABLE_SYNC_CREATE);
               return null;
             }
             parent = getFullNameParent(activeInstance, jobFullName, getNamespace(buildConfig));
@@ -288,7 +288,6 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
           if (workflowJob == null) {
             logger.warning("Could not find created job " + fullName + " for BuildConfig: " + getNamespace(buildConfig) + "/" + getName(buildConfig));
           } else {
-            //logger.info((newJob ? "created" : "updated" ) + " job " + fullName + " with path " + jobFullName + " from BuildConfig: " + getNamespace(buildConfig) + "/" + getName(buildConfig));
             putJobWithBuildConfig(workflowJob, buildConfig);
           }
           return null;

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -68,352 +68,289 @@ import static java.util.logging.Level.SEVERE;
  * ensure there is a suitable Jenkins Job object defined with the correct
  * configuration
  */
-public class BuildConfigWatcher extends BaseWatcher implements
-        Watcher<BuildConfig> {
-    private final Logger logger = Logger.getLogger(getClass().getName());
+public class BuildConfigWatcher extends BaseWatcher implements Watcher<BuildConfig> {
+	private final Logger logger = Logger.getLogger(getClass().getName());
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public BuildConfigWatcher(String[] namespaces) {
-      super(namespaces);
-    }
+	@SuppressFBWarnings("EI_EXPOSE_REP2")
+	public BuildConfigWatcher(String[] namespaces) {
+		super(namespaces);
+	}
 
-    public Runnable getStartTimerTask() {
-        return new SafeTimerTask() {
-            @Override
-            public void doRun() {
-                if (!CredentialsUtils.hasCredentials()) {
-                    logger.fine("No Openshift Token credential defined.");
-                    return;
-                }
-                for (String namespace : namespaces) {
-                    try {
-                        logger.fine("listing BuildConfigs resources");
-                        final BuildConfigList buildConfigs = getAuthenticatedOpenShiftClient()
-                                .buildConfigs().inNamespace(namespace).list();
-                        onInitialBuildConfigs(buildConfigs);
-                        logger.fine("handled BuildConfigs resources");
-                        if (watches.get(namespace) == null) {
-                            logger.info("creating BuildConfig watch for namespace "
-                                    + namespace
-                                    + " and resource version "
-                                    + buildConfigs.getMetadata()
-                                            .getResourceVersion());
-                            watches.put(
-                                    namespace,
-                                    getAuthenticatedOpenShiftClient()
-                                            .buildConfigs()
-                                            .inNamespace(namespace)
-                                            .withResourceVersion(
-                                                    buildConfigs
-                                                            .getMetadata()
-                                                            .getResourceVersion())
-                                            .watch(BuildConfigWatcher.this));
-                        }
-                    } catch (Exception e) {
-                        logger.log(SEVERE, "Failed to load BuildConfigs: " + e,
-                                e);
-                    }
-                }
-                // poke the BuildWatcher builds with no BC list and see if we
-                // can create job
-                // runs for premature builds
-                BuildWatcher.flushBuildsWithNoBCList();
-            }
-        };
-    }
+	public Runnable getStartTimerTask() {
+		return new SafeTimerTask() {
+			@Override
+			public void doRun() {
+				if (!CredentialsUtils.hasCredentials()) {
+					logger.fine("No Openshift Token credential defined.");
+					return;
+				}
+				for (String namespace : namespaces) {
+					try {
+						logger.fine("listing BuildConfigs resources");
+						final BuildConfigList buildConfigs = getAuthenticatedOpenShiftClient().buildConfigs()
+								.inNamespace(namespace).list();
+						onInitialBuildConfigs(buildConfigs);
+						logger.fine("handled BuildConfigs resources");
+						if (watches.get(namespace) == null) {
+							logger.info("creating BuildConfig watch for namespace " + namespace
+									+ " and resource version " + buildConfigs.getMetadata().getResourceVersion());
+							watches.put(namespace,
+									getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace)
+											.withResourceVersion(buildConfigs.getMetadata().getResourceVersion())
+											.watch(BuildConfigWatcher.this));
+						}
+					} catch (Exception e) {
+						logger.log(SEVERE, "Failed to load BuildConfigs: " + e, e);
+					}
+				}
+				// poke the BuildWatcher builds with no BC list and see if we
+				// can create job
+				// runs for premature builds
+				BuildWatcher.flushBuildsWithNoBCList();
+			}
+		};
+	}
 
-    public synchronized void start() {
-        initializeBuildConfigToJobMap();
-        logger.info("Now handling startup build configs!!");
-        super.start();
+	public synchronized void start() {
+		initializeBuildConfigToJobMap();
+		logger.info("Now handling startup build configs!!");
+		super.start();
 
-    }
+	}
 
-    private synchronized void onInitialBuildConfigs(BuildConfigList buildConfigs) {
-        List<BuildConfig> items = buildConfigs.getItems();
-        if (items != null) {
-            for (BuildConfig buildConfig : items) {
-                try {
-                    upsertJob(buildConfig);
-                } catch (Exception e) {
-                    logger.log(SEVERE, "Failed to update job", e);
-                }
-            }
-        }
-    }
+	private synchronized void onInitialBuildConfigs(BuildConfigList buildConfigs) {
+		List<BuildConfig> items = buildConfigs.getItems();
+		if (items != null) {
+			for (BuildConfig buildConfig : items) {
+				try {
+					upsertJob(buildConfig);
+				} catch (Exception e) {
+					logger.log(SEVERE, "Failed to update job", e);
+				}
+			}
+		}
+	}
 
-    @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
-    @Override
-    public synchronized void eventReceived(Watcher.Action action,
-            BuildConfig buildConfig) {
-        try {
-            switch (action) {
-            case ADDED:
-                upsertJob(buildConfig);
-                break;
-            case DELETED:
-                deleteEventToJenkinsJob(buildConfig);
-                break;
-            case MODIFIED:
-                modifyEventToJenkinsJob(buildConfig);
-                break;
-            }
-            // if bc event came after build events, let's
-            // poke the BuildWatcher builds with no BC list to create job
-            // runs
-            BuildWatcher.flushBuildsWithNoBCList();
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Caught: " + e, e);
-        }
-    }
+	@SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
+	@Override
+	public synchronized void eventReceived(Watcher.Action action, BuildConfig buildConfig) {
+		try {
+			switch (action) {
+			case ADDED:
+				upsertJob(buildConfig);
+				break;
+			case DELETED:
+				deleteEventToJenkinsJob(buildConfig);
+				break;
+			case MODIFIED:
+				modifyEventToJenkinsJob(buildConfig);
+				break;
+			}
+			// if bc event came after build events, let's
+			// poke the BuildWatcher builds with no BC list to create job
+			// runs
+			BuildWatcher.flushBuildsWithNoBCList();
+		} catch (Exception e) {
+			logger.log(Level.WARNING, "Caught: " + e, e);
+		}
+	}
 
-    private void updateJob(WorkflowJob job, InputStream jobStream,
-            String jobName, BuildConfig buildConfig,
-            String existingBuildRunPolicy,
-            BuildConfigProjectProperty buildConfigProjectProperty)
-            throws IOException {
-        Source source = new StreamSource(jobStream);
-        job.updateByXml(source);
-        job.save();
-        logger.info("Updated job " + jobName + " from BuildConfig "
-                + NamespaceName.create(buildConfig) + " with revision: "
-                + buildConfig.getMetadata().getResourceVersion());
-        if (existingBuildRunPolicy != null
-                && !existingBuildRunPolicy.equals(buildConfigProjectProperty
-                        .getBuildRunPolicy())) {
-            maybeScheduleNext(job);
-        }
-    }
+	private void updateJob(WorkflowJob job, InputStream jobStream, String jobName, BuildConfig buildConfig,
+			String existingBuildRunPolicy, BuildConfigProjectProperty buildConfigProjectProperty) throws IOException {
+		Source source = new StreamSource(jobStream);
+		job.updateByXml(source);
+		job.save();
+		logger.info("Updated job " + jobName + " from BuildConfig " + NamespaceName.create(buildConfig)
+				+ " with revision: " + buildConfig.getMetadata().getResourceVersion());
+		if (existingBuildRunPolicy != null
+				&& !existingBuildRunPolicy.equals(buildConfigProjectProperty.getBuildRunPolicy())) {
+			maybeScheduleNext(job);
+		}
+	}
 
-    private void upsertJob(final BuildConfig buildConfig) throws Exception {
-        if (isPipelineStrategyBuildConfig(buildConfig)) {
-            // sync on intern of name should guarantee sync on same actual obj
-            synchronized (buildConfig.getMetadata().getUid().intern()) {
-                ACL.impersonate(ACL.SYSTEM,
-                        new NotReallyRoleSensitiveCallable<Void, Exception>() {
-                            @Override
-                            public Void call() throws Exception {
-                                String jobName = jenkinsJobName(buildConfig);
-                                String jobFullName = jenkinsJobFullName(buildConfig);
-                                WorkflowJob job = getJobFromBuildConfig(buildConfig);
-                                Jenkins activeInstance = Jenkins.getActiveInstance();
-                                ItemGroup parent = activeInstance;
-                                if (job == null) {
-                                  job = (WorkflowJob) activeInstance.getItemByFullName(jobFullName);
-                                }
-                                boolean newJob = job == null;
-                                if (newJob) {
-                                    String disableOn = getAnnotation(buildConfig, DISABLE_SYNC_CREATE);
-                                    if (disableOn != null && disableOn.equalsIgnoreCase("jenkins")) {
-                                      logger.fine("Not creating missing jenkins job "
-                                                  + jobFullName + " due to annotation: " + DISABLE_SYNC_CREATE);
-                                      return null;
-                                    }
-                                    parent = getFullNameParent(activeInstance, jobFullName, getNamespace(buildConfig));
-                                    job = new WorkflowJob(parent, jobName);
-                                }
-                                BulkChange bk = new BulkChange(job);
+	private void upsertJob(final BuildConfig buildConfig) throws Exception {
+		if (isPipelineStrategyBuildConfig(buildConfig)) {
+			// sync on intern of name should guarantee sync on same actual obj
+			synchronized (buildConfig.getMetadata().getUid().intern()) {
+				ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
+					@Override
+					public Void call() throws Exception {
+						String jobName = jenkinsJobName(buildConfig);
+						String jobFullName = jenkinsJobFullName(buildConfig);
+						WorkflowJob job = getJobFromBuildConfig(buildConfig);
+						Jenkins activeInstance = Jenkins.getActiveInstance();
+						ItemGroup parent = activeInstance;
+						if (job == null) {
+							job = (WorkflowJob) activeInstance.getItemByFullName(jobFullName);
+						}
+						boolean newJob = job == null;
+						if (newJob) {
+							String disableOn = getAnnotation(buildConfig, DISABLE_SYNC_CREATE);
+							if (disableOn != null && disableOn.equalsIgnoreCase("jenkins")) {
+								logger.fine("Not creating missing jenkins job " + jobFullName + " due to annotation: "
+										+ DISABLE_SYNC_CREATE);
+								return null;
+							}
+							parent = getFullNameParent(activeInstance, jobFullName, getNamespace(buildConfig));
+							job = new WorkflowJob(parent, jobName);
+						}
+						BulkChange bk = new BulkChange(job);
 
-                                job.setDisplayName(jenkinsJobDisplayName(buildConfig));
+						job.setDisplayName(jenkinsJobDisplayName(buildConfig));
 
-                                FlowDefinition flowFromBuildConfig = mapBuildConfigToFlow(buildConfig);
-                                if (flowFromBuildConfig == null) {
-                                    return null;
-                                }
+						FlowDefinition flowFromBuildConfig = mapBuildConfigToFlow(buildConfig);
+						if (flowFromBuildConfig == null) {
+							return null;
+						}
 
-                                job.setDefinition(flowFromBuildConfig);
+						job.setDefinition(flowFromBuildConfig);
 
-                                String existingBuildRunPolicy = null;
+						String existingBuildRunPolicy = null;
 
-                                BuildConfigProjectProperty buildConfigProjectProperty = job
-                                        .getProperty(BuildConfigProjectProperty.class);
-                                if (buildConfigProjectProperty != null) {
-                                    existingBuildRunPolicy = buildConfigProjectProperty
-                                            .getBuildRunPolicy();
-                                    long updatedBCResourceVersion = parseResourceVersion(buildConfig);
-                                    long oldBCResourceVersion = parseResourceVersion(buildConfigProjectProperty
-                                            .getResourceVersion());
-                                    BuildConfigProjectProperty newProperty = new BuildConfigProjectProperty(
-                                            buildConfig);
-                                    if (updatedBCResourceVersion <= oldBCResourceVersion
-                                            && newProperty.getUid().equals(
-                                                    buildConfigProjectProperty
-                                                            .getUid())
-                                            && newProperty
-                                                    .getNamespace()
-                                                    .equals(buildConfigProjectProperty
-                                                            .getNamespace())
-                                            && newProperty.getName().equals(
-                                                    buildConfigProjectProperty
-                                                            .getName())
-                                            && newProperty
-                                                    .getBuildRunPolicy()
-                                                    .equals(buildConfigProjectProperty
-                                                            .getBuildRunPolicy())) {
-                                        return null;
-                                    }
-                                    buildConfigProjectProperty
-                                            .setUid(newProperty.getUid());
-                                    buildConfigProjectProperty
-                                            .setNamespace(newProperty
-                                                    .getNamespace());
-                                    buildConfigProjectProperty
-                                            .setName(newProperty.getName());
-                                    buildConfigProjectProperty
-                                            .setResourceVersion(newProperty
-                                                    .getResourceVersion());
-                                    buildConfigProjectProperty
-                                            .setBuildRunPolicy(newProperty
-                                                    .getBuildRunPolicy());
-                                } else {
-                                    job.addProperty(new BuildConfigProjectProperty(
-                                            buildConfig));
-                                }
+						BuildConfigProjectProperty buildConfigProjectProperty = job
+								.getProperty(BuildConfigProjectProperty.class);
+						if (buildConfigProjectProperty != null) {
+							existingBuildRunPolicy = buildConfigProjectProperty.getBuildRunPolicy();
+							long updatedBCResourceVersion = parseResourceVersion(buildConfig);
+							long oldBCResourceVersion = parseResourceVersion(
+									buildConfigProjectProperty.getResourceVersion());
+							BuildConfigProjectProperty newProperty = new BuildConfigProjectProperty(buildConfig);
+							if (updatedBCResourceVersion <= oldBCResourceVersion
+									&& newProperty.getUid().equals(buildConfigProjectProperty.getUid())
+									&& newProperty.getNamespace().equals(buildConfigProjectProperty.getNamespace())
+									&& newProperty.getName().equals(buildConfigProjectProperty.getName())
+									&& newProperty.getBuildRunPolicy()
+											.equals(buildConfigProjectProperty.getBuildRunPolicy())) {
+								return null;
+							}
+							buildConfigProjectProperty.setUid(newProperty.getUid());
+							buildConfigProjectProperty.setNamespace(newProperty.getNamespace());
+							buildConfigProjectProperty.setName(newProperty.getName());
+							buildConfigProjectProperty.setResourceVersion(newProperty.getResourceVersion());
+							buildConfigProjectProperty.setBuildRunPolicy(newProperty.getBuildRunPolicy());
+						} else {
+							job.addProperty(new BuildConfigProjectProperty(buildConfig));
+						}
 
-                                // (re)populate job param list with any envs
-                                // from the build config
-                                JenkinsUtils.addJobParamForBuildEnvs(job,
-                                        buildConfig.getSpec().getStrategy()
-                                                .getJenkinsPipelineStrategy(),
-                                        true);
+						// (re)populate job param list with any envs
+						// from the build config
+						JenkinsUtils.addJobParamForBuildEnvs(job,
+								buildConfig.getSpec().getStrategy().getJenkinsPipelineStrategy(), true);
 
-                                job.setConcurrentBuild(!(buildConfig.getSpec()
-                                        .getRunPolicy().equals(SERIAL) || buildConfig
-                                        .getSpec().getRunPolicy()
-                                        .equals(SERIAL_LATEST_ONLY)));
+						job.setConcurrentBuild(!(buildConfig.getSpec().getRunPolicy().equals(SERIAL)
+								|| buildConfig.getSpec().getRunPolicy().equals(SERIAL_LATEST_ONLY)));
 
-                                InputStream jobStream = new StringInputStream(
-                                        new XStream2().toXML(job));
+						InputStream jobStream = new StringInputStream(new XStream2().toXML(job));
 
-                                if (newJob) {
-                                    try {
-                                        if (parent instanceof Folder){
-                                            Folder folder = (Folder) parent;
-                                            folder.createProjectFromXML(
-                                            jobName,
-                                            jobStream
-                                          ).save();
-                                        }else{
-                                          activeInstance.createProjectFromXML(
-                                            jobName,
-                                            jobStream
-                                          ).save();
-                                        }
+						if (newJob) {
+							try {
+								if (parent instanceof Folder) {
+									Folder folder = (Folder) parent;
+									folder.createProjectFromXML(jobName, jobStream).save();
+								} else {
+									activeInstance.createProjectFromXML(jobName, jobStream).save();
+								}
 
-                                        logger.info("Created job "
-                                                + jobName
-                                                + " from BuildConfig "
-                                                + NamespaceName
-                                                        .create(buildConfig)
-                                                + " with revision: "
-                                                + buildConfig.getMetadata()
-                                                        .getResourceVersion());
-                                    } catch (IllegalArgumentException e) {
-                                        // see
-                                        // https://github.com/openshift/jenkins-sync-plugin/issues/117,
-                                        // jenkins might reload existing jobs on
-                                        // startup between the
-                                        // newJob check above and when we make
-                                        // the createProjectFromXML call; if so,
-                                        // retry as an update
-                                        updateJob(job, jobStream, jobName,
-                                                buildConfig,
-                                                existingBuildRunPolicy,
-                                                buildConfigProjectProperty);
-                                    }
-                                } else {
-                                    updateJob(job, jobStream, jobName,
-                                            buildConfig,
-                                            existingBuildRunPolicy,
-                                            buildConfigProjectProperty);
-                                }
-                                bk.commit();
-                                String fullName = job.getFullName();
-                                WorkflowJob workflowJob = activeInstance.getItemByFullName(fullName, WorkflowJob.class);
-                                if (workflowJob == null && parent instanceof Folder) {
-                                    // we should never need this but just in case there's an
-                                    // odd timing issue or something...
-                                    Folder folder = (Folder) parent;
-                                    folder.add(job, jobName);
-                                    workflowJob = activeInstance.getItemByFullName(fullName, WorkflowJob.class);
+								logger.info("Created job " + jobName + " from BuildConfig "
+										+ NamespaceName.create(buildConfig) + " with revision: "
+										+ buildConfig.getMetadata().getResourceVersion());
+							} catch (IllegalArgumentException e) {
+								// see
+								// https://github.com/openshift/jenkins-sync-plugin/issues/117,
+								// jenkins might reload existing jobs on
+								// startup between the
+								// newJob check above and when we make
+								// the createProjectFromXML call; if so,
+								// retry as an update
+								updateJob(job, jobStream, jobName, buildConfig, existingBuildRunPolicy,
+										buildConfigProjectProperty);
+							}
+						} else {
+							updateJob(job, jobStream, jobName, buildConfig, existingBuildRunPolicy,
+									buildConfigProjectProperty);
+						}
+						bk.commit();
+						String fullName = job.getFullName();
+						WorkflowJob workflowJob = activeInstance.getItemByFullName(fullName, WorkflowJob.class);
+						if (workflowJob == null && parent instanceof Folder) {
+							// we should never need this but just in case there's an
+							// odd timing issue or something...
+							Folder folder = (Folder) parent;
+							folder.add(job, jobName);
+							workflowJob = activeInstance.getItemByFullName(fullName, WorkflowJob.class);
 
-                                }
-                                if (workflowJob == null){
-                                    logger.warning("Could not find created job " + fullName + " for BuildConfig: "
-                                      + getNamespace(buildConfig) + "/" + getName(buildConfig));
-                                }else{
-                                    putJobWithBuildConfig(workflowJob, buildConfig);
-                                }
-                                return null;
-                            }
-                        });
-            }
-        }
-    }
+						}
+						if (workflowJob == null) {
+							logger.warning("Could not find created job " + fullName + " for BuildConfig: "
+									+ getNamespace(buildConfig) + "/" + getName(buildConfig));
+						} else {
+							putJobWithBuildConfig(workflowJob, buildConfig);
+						}
+						return null;
+					}
+				});
+			}
+		}
+	}
 
-    private synchronized void modifyEventToJenkinsJob(BuildConfig buildConfig)
-            throws Exception {
-        if (isPipelineStrategyBuildConfig(buildConfig)) {
-            upsertJob(buildConfig);
-            return;
-        }
+	private synchronized void modifyEventToJenkinsJob(BuildConfig buildConfig) throws Exception {
+		if (isPipelineStrategyBuildConfig(buildConfig)) {
+			upsertJob(buildConfig);
+			return;
+		}
 
-        // no longer a Jenkins build so lets delete it if it exists
-        deleteEventToJenkinsJob(buildConfig);
-    }
+		// no longer a Jenkins build so lets delete it if it exists
+		deleteEventToJenkinsJob(buildConfig);
+	}
 
-    // innerDeleteEventToJenkinsJob is the actual delete logic at the heart of
-    // deleteEventToJenkinsJob
-    // that is either in a sync block or not based on the presence of a BC uid
-    private void innerDeleteEventToJenkinsJob(final BuildConfig buildConfig)
-            throws Exception {
-        final Job job = getJobFromBuildConfig(buildConfig);
-        if (job != null) {
-            // employ intern of the BC UID to facilitate sync'ing on the same
-            // actual object
-            synchronized (buildConfig.getMetadata().getUid().intern()) {
-                ACL.impersonate(ACL.SYSTEM,
-                        new NotReallyRoleSensitiveCallable<Void, Exception>() {
-                            @Override
-                            public Void call() throws Exception {
-                                try {
-                                    job.delete();
-                                } finally {
-                                    removeJobWithBuildConfig(buildConfig);
-                                    Jenkins.getActiveInstance()
-                                            .rebuildDependencyGraphAsync();
-                                }
-                                return null;
-                            }
-                        });
-            }
+	// innerDeleteEventToJenkinsJob is the actual delete logic at the heart of
+	// deleteEventToJenkinsJob
+	// that is either in a sync block or not based on the presence of a BC uid
+	private void innerDeleteEventToJenkinsJob(final BuildConfig buildConfig) throws Exception {
+		final Job job = getJobFromBuildConfig(buildConfig);
+		if (job != null) {
+			// employ intern of the BC UID to facilitate sync'ing on the same
+			// actual object
+			synchronized (buildConfig.getMetadata().getUid().intern()) {
+				ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
+					@Override
+					public Void call() throws Exception {
+						try {
+							job.delete();
+						} finally {
+							removeJobWithBuildConfig(buildConfig);
+							Jenkins.getActiveInstance().rebuildDependencyGraphAsync();
+						}
+						return null;
+					}
+				});
+			}
 
-        }
+		}
 
-    }
+	}
 
-    // in response to receiving an openshift delete build config event, this
-    // method will drive
-    // the clean up of the Jenkins job the build config is mapped one to one
-    // with; as part of that
-    // clean up it will synchronize with the build event watcher to handle build
-    // config
-    // delete events and build delete events that arrive concurrently and in a
-    // nondeterministic
-    // order
-    private synchronized void deleteEventToJenkinsJob(
-            final BuildConfig buildConfig) throws Exception {
-        String bcUid = buildConfig.getMetadata().getUid();
-        if (bcUid != null && bcUid.length() > 0) {
-            // employ intern of the BC UID to facilitate sync'ing on the same
-            // actual object
-            bcUid = bcUid.intern();
-            synchronized (bcUid) {
-                innerDeleteEventToJenkinsJob(buildConfig);
-                return;
-            }
-        }
-        // uid should not be null / empty, but just in case, still clean up
-        innerDeleteEventToJenkinsJob(buildConfig);
-    }
+	// in response to receiving an openshift delete build config event, this
+	// method will drive
+	// the clean up of the Jenkins job the build config is mapped one to one
+	// with; as part of that
+	// clean up it will synchronize with the build event watcher to handle build
+	// config
+	// delete events and build delete events that arrive concurrently and in a
+	// nondeterministic
+	// order
+	private synchronized void deleteEventToJenkinsJob(final BuildConfig buildConfig) throws Exception {
+		String bcUid = buildConfig.getMetadata().getUid();
+		if (bcUid != null && bcUid.length() > 0) {
+			// employ intern of the BC UID to facilitate sync'ing on the same
+			// actual object
+			bcUid = bcUid.intern();
+			synchronized (bcUid) {
+				innerDeleteEventToJenkinsJob(buildConfig);
+				return;
+			}
+		}
+		// uid should not be null / empty, but just in case, still clean up
+		innerDeleteEventToJenkinsJob(buildConfig);
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -51,16 +51,7 @@ import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMapper.mapBuildCo
 import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL;
 import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL_LATEST_ONLY;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.maybeScheduleNext;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAnnotation;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getFullNameParent;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getName;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getNamespace;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isPipelineStrategyBuildConfig;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobFullName;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobName;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobDisplayName;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.parseResourceVersion;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
 import static java.util.logging.Level.SEVERE;
 
 /**
@@ -118,20 +109,20 @@ public class BuildConfigWatcher extends BaseWatcher implements Watcher<BuildConf
 
 	}
 
-    private synchronized void onInitialBuildConfigs(BuildConfigList buildConfigs) {
-        if (buildConfigs == null)
-            return;
-        List<BuildConfig> items = buildConfigs.getItems();
-        if (items != null) {
-            for (BuildConfig buildConfig : items) {
-                try {
-                    upsertJob(buildConfig);
-                } catch (Exception e) {
-                    logger.log(SEVERE, "Failed to update job", e);
-                }
-            }
-        }
-    }
+	private synchronized void onInitialBuildConfigs(BuildConfigList buildConfigs) {
+		if (buildConfigs == null)
+			return;
+		List<BuildConfig> items = buildConfigs.getItems();
+		if (items != null) {
+			for (BuildConfig buildConfig : items) {
+				try {
+					upsertJob(buildConfig);
+				} catch (Exception e) {
+					logger.log(SEVERE, "Failed to update job", e);
+				}
+			}
+		}
+	}
 
 	@SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
 	@Override
@@ -188,7 +179,7 @@ public class BuildConfigWatcher extends BaseWatcher implements Watcher<BuildConf
 						boolean newJob = job == null;
 						if (newJob) {
 							String disableOn = getAnnotation(buildConfig, DISABLE_SYNC_CREATE);
-							if (disableOn != null && disableOn.equalsIgnoreCase("jenkins")) {
+							if (disableOn != null && disableOn.length() > 0) {
 								logger.fine("Not creating missing jenkins job " + jobFullName + " due to annotation: "
 										+ DISABLE_SYNC_CREATE);
 								return null;

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -347,6 +347,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
     }
   }
 
+  //annotate the Build with pending input JSON so consoles can do the Proceed/Abort stuff if they want
   private String getPendingActionsJson(WorkflowRun run) {
     List<PendingInputActionsExt> pendingInputActions = new ArrayList<PendingInputActionsExt>();
     InputAction inputAction = run.getAction(InputAction.class);

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -17,11 +17,12 @@ package io.fabric8.jenkins.openshiftsync;
 
 import com.cloudbees.workflow.rest.external.AtomFlowNodeExt;
 import com.cloudbees.workflow.rest.external.FlowNodeExt;
+import com.cloudbees.workflow.rest.external.PendingInputActionsExt;
 import com.cloudbees.workflow.rest.external.RunExt;
 import com.cloudbees.workflow.rest.external.StageNodeExt;
+import com.cloudbees.workflow.rest.external.StatusExt;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.Result;
@@ -31,17 +32,22 @@ import hudson.model.listeners.RunListener;
 import hudson.triggers.SafeTimerTask;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildFluent;
+import io.fabric8.openshift.api.model.DoneableBuild;
 import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
-
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +57,8 @@ import java.util.logging.Logger;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.maybeScheduleNext;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.formatTimestamp;
@@ -251,6 +259,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
             logger.log(Level.FINE, "upsertBuild", t);
     }
 
+    boolean pendingInput = false;
     if (!wfRunExt.get_links().self.href.matches("^https?://.*$")) {
       wfRunExt.get_links().self.setHref(joinPaths(rootUrl, wfRunExt.get_links().self.href));
     }
@@ -271,6 +280,10 @@ public class BuildSyncRunListener extends RunListener<Run> {
           nodeLinks.getLog().setHref(joinPaths(rootUrl, nodeLinks.getLog().href));
         }
       }
+      StatusExt status = stage.getStatus();
+      if (status != null && status.equals(StatusExt.PAUSED_PENDING_INPUT)) {
+        pendingInput = true;
+      }
     }
 
     String json;
@@ -281,6 +294,10 @@ public class BuildSyncRunListener extends RunListener<Run> {
       return;
     }
 
+    String pendingActionsJson = null;
+    if (pendingInput && run instanceof WorkflowRun) {
+      pendingActionsJson = getPendingActionsJson((WorkflowRun) run);
+    }
     String phase = runToBuildPhase(run);
 
     long started = getStartTime(run);
@@ -297,13 +314,23 @@ public class BuildSyncRunListener extends RunListener<Run> {
 
     logger.log(FINE, "Patching build {0}/{1}: setting phase to {2}", new Object[]{cause.getNamespace(), cause.getName(), phase});
     try {
-      getAuthenticatedOpenShiftClient().builds().inNamespace(cause.getNamespace()).withName(cause.getName()).edit()
+
+      BuildFluent.MetadataNested<DoneableBuild> builder = getAuthenticatedOpenShiftClient().builds().inNamespace(cause.getNamespace()).withName(cause.getName()).edit()
         .editMetadata()
         .addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON, json)
         .addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI, buildUrl)
         .addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL, logsUrl)
         .addToAnnotations(Constants.OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL, logsConsoleUrl)
-        .addToAnnotations(Constants.OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL, logsBlueOceanUrl)
+        .addToAnnotations(Constants.OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL, logsBlueOceanUrl);
+
+      String jenkinsNamespace = System.getenv("KUBERNETES_NAMESPACE");
+      if (jenkinsNamespace != null && !jenkinsNamespace.isEmpty()) {
+        builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE, jenkinsNamespace);
+      }
+      if (pendingActionsJson != null && !pendingActionsJson.isEmpty()) {
+        builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON, pendingActionsJson);
+      }
+      builder
         .endMetadata()
         .editStatus()
         .withPhase(phase)
@@ -317,6 +344,26 @@ public class BuildSyncRunListener extends RunListener<Run> {
       } else {
         throw e;
       }
+    }
+  }
+
+  private String getPendingActionsJson(WorkflowRun run) {
+    List<PendingInputActionsExt> pendingInputActions = new ArrayList<PendingInputActionsExt>();
+    InputAction inputAction = run.getAction(InputAction.class);
+
+    if (inputAction != null) {
+      List<InputStepExecution> executions = inputAction.getExecutions();
+      if (executions != null && !executions.isEmpty()) {
+        for (InputStepExecution inputStepExecution : executions) {
+          pendingInputActions.add(PendingInputActionsExt.create(inputStepExecution, run));
+        }
+      }
+    }
+    try {
+      return new ObjectMapper().writeValueAsString(pendingInputActions);
+    } catch (JsonProcessingException e) {
+      logger.log(SEVERE, "Failed to serialize pending actions. " + e, e);
+      return null;
     }
   }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -76,419 +76,382 @@ import static java.util.logging.Level.WARNING;
  */
 @Extension
 public class BuildSyncRunListener extends RunListener<Run> {
-    private static final Logger logger = Logger
-            .getLogger(BuildSyncRunListener.class.getName());
+	private static final Logger logger = Logger.getLogger(BuildSyncRunListener.class.getName());
 
-    private long pollPeriodMs = 1000;
-    private static final long maxDelay = 30000;
+	private long pollPeriodMs = 1000;
+	private static final long maxDelay = 30000;
 
-    private transient Set<Run> runsToPoll = new CopyOnWriteArraySet<>();
+	private transient Set<Run> runsToPoll = new CopyOnWriteArraySet<>();
 
-    private transient AtomicBoolean timerStarted = new AtomicBoolean(false);
+	private transient AtomicBoolean timerStarted = new AtomicBoolean(false);
 
-    public BuildSyncRunListener() {
-    }
+	public BuildSyncRunListener() {
+	}
 
-    @DataBoundConstructor
-    public BuildSyncRunListener(long pollPeriodMs) {
-        this.pollPeriodMs = pollPeriodMs;
-    }
+	@DataBoundConstructor
+	public BuildSyncRunListener(long pollPeriodMs) {
+		this.pollPeriodMs = pollPeriodMs;
+	}
 
-    /**
-     * Joins all the given strings, ignoring nulls so that they form a URL with
-     * / between the paths without a // if the previous path ends with / and the
-     * next path starts with / unless a path item is blank
-     *
-     * @param strings
-     *            the sequence of strings to join
-     * @return the strings concatenated together with / while avoiding a double
-     *         // between non blank strings.
-     */
-    public static String joinPaths(String... strings) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < strings.length; i++) {
-            sb.append(strings[i]);
-            if (i < strings.length - 1) {
-                sb.append("/");
-            }
-        }
-        String joined = sb.toString();
+	/**
+	 * Joins all the given strings, ignoring nulls so that they form a URL with /
+	 * between the paths without a // if the previous path ends with / and the next
+	 * path starts with / unless a path item is blank
+	 *
+	 * @param strings
+	 *            the sequence of strings to join
+	 * @return the strings concatenated together with / while avoiding a double //
+	 *         between non blank strings.
+	 */
+	public static String joinPaths(String... strings) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < strings.length; i++) {
+			sb.append(strings[i]);
+			if (i < strings.length - 1) {
+				sb.append("/");
+			}
+		}
+		String joined = sb.toString();
 
-        // And normalize it...
-        return joined.replaceAll("/+", "/").replaceAll("/\\?", "?")
-                .replaceAll("/#", "#").replaceAll(":/", "://");
-    }
+		// And normalize it...
+		return joined.replaceAll("/+", "/").replaceAll("/\\?", "?").replaceAll("/#", "#").replaceAll(":/", "://");
+	}
 
-    @Override
-    public synchronized void onStarted(Run run, TaskListener listener) {
-        if (shouldPollRun(run)) {
-            try {
-                BuildCause cause = (BuildCause) run.getCause(BuildCause.class);
-                if (cause != null) {
-                    // TODO This should be a link to the OpenShift console.
-                    run.setDescription(cause.getShortDescription());
-                }
-            } catch (IOException e) {
-                logger.log(WARNING, "Cannot set build description: " + e);
-            }
-            if (runsToPoll.add(run)) {
-                logger.info("starting polling build " + run.getUrl());
-            }
-            checkTimerStarted();
-        } else {
-            logger.fine("not polling polling build " + run.getUrl()
-                    + " as its not a WorkflowJob");
-        }
-        super.onStarted(run, listener);
-    }
+	@Override
+	public synchronized void onStarted(Run run, TaskListener listener) {
+		if (shouldPollRun(run)) {
+			try {
+				BuildCause cause = (BuildCause) run.getCause(BuildCause.class);
+				if (cause != null) {
+					// TODO This should be a link to the OpenShift console.
+					run.setDescription(cause.getShortDescription());
+				}
+			} catch (IOException e) {
+				logger.log(WARNING, "Cannot set build description: " + e);
+			}
+			if (runsToPoll.add(run)) {
+				logger.info("starting polling build " + run.getUrl());
+			}
+			checkTimerStarted();
+		} else {
+			logger.fine("not polling polling build " + run.getUrl() + " as its not a WorkflowJob");
+		}
+		super.onStarted(run, listener);
+	}
 
-    protected void checkTimerStarted() {
-        if (timerStarted.compareAndSet(false, true)) {
-            Runnable task = new SafeTimerTask() {
-                @Override
-                protected void doRun() throws Exception {
-                    pollLoop();
-                }
-            };
-            Timer.get().scheduleAtFixedRate(task, pollPeriodMs, pollPeriodMs,
-                    TimeUnit.MILLISECONDS);
-        }
-    }
+	protected void checkTimerStarted() {
+		if (timerStarted.compareAndSet(false, true)) {
+			Runnable task = new SafeTimerTask() {
+				@Override
+				protected void doRun() throws Exception {
+					pollLoop();
+				}
+			};
+			Timer.get().scheduleAtFixedRate(task, pollPeriodMs, pollPeriodMs, TimeUnit.MILLISECONDS);
+		}
+	}
 
-    @Override
-    public synchronized void onCompleted(Run run, @Nonnull TaskListener listener) {
-        if (shouldPollRun(run)) {
-            runsToPoll.remove(run);
-            pollRun(run);
-            logger.info("onCompleted " + run.getUrl());
-            maybeScheduleNext(((WorkflowRun) run).getParent());
-        }
-        super.onCompleted(run, listener);
-    }
+	@Override
+	public synchronized void onCompleted(Run run, @Nonnull TaskListener listener) {
+		if (shouldPollRun(run)) {
+			runsToPoll.remove(run);
+			pollRun(run);
+			logger.info("onCompleted " + run.getUrl());
+			maybeScheduleNext(((WorkflowRun) run).getParent());
+		}
+		super.onCompleted(run, listener);
+	}
 
-    @Override
-    public synchronized void onDeleted(Run run) {
-        if (shouldPollRun(run)) {
-            runsToPoll.remove(run);
-            pollRun(run);
-            logger.info("onDeleted " + run.getUrl());
-            maybeScheduleNext(((WorkflowRun) run).getParent());
-        }
-        super.onDeleted(run);
-    }
+	@Override
+	public synchronized void onDeleted(Run run) {
+		if (shouldPollRun(run)) {
+			runsToPoll.remove(run);
+			pollRun(run);
+			logger.info("onDeleted " + run.getUrl());
+			maybeScheduleNext(((WorkflowRun) run).getParent());
+		}
+		super.onDeleted(run);
+	}
 
-    @Override
-    public synchronized void onFinalized(Run run) {
-        if (shouldPollRun(run)) {
-            runsToPoll.remove(run);
-            pollRun(run);
-            logger.info("onFinalized " + run.getUrl());
-        }
-        super.onFinalized(run);
-    }
+	@Override
+	public synchronized void onFinalized(Run run) {
+		if (shouldPollRun(run)) {
+			runsToPoll.remove(run);
+			pollRun(run);
+			logger.info("onFinalized " + run.getUrl());
+		}
+		super.onFinalized(run);
+	}
 
-    protected synchronized void pollLoop() {
-        for (Run run : runsToPoll) {
-            pollRun(run);
-        }
-    }
+	protected synchronized void pollLoop() {
+		for (Run run : runsToPoll) {
+			pollRun(run);
+		}
+	}
 
-    protected synchronized void pollRun(Run run) {
-        if (!(run instanceof WorkflowRun)) {
-            throw new IllegalStateException("Cannot poll a non-workflow run");
-        }
+	protected synchronized void pollRun(Run run) {
+		if (!(run instanceof WorkflowRun)) {
+			throw new IllegalStateException("Cannot poll a non-workflow run");
+		}
 
-        RunExt wfRunExt = RunExt.create((WorkflowRun) run);
+		RunExt wfRunExt = RunExt.create((WorkflowRun) run);
 
-        try {
-            upsertBuild(run, wfRunExt);
-        } catch (KubernetesClientException e) {
-            if (e.getCode() == HttpStatus.SC_UNPROCESSABLE_ENTITY) {
-                runsToPoll.remove(run);
-                logger.log(WARNING, "Cannot update status: {0}", e.getMessage());
-                return;
-            }
-            throw e;
-        }
-    }
+		try {
+			upsertBuild(run, wfRunExt);
+		} catch (KubernetesClientException e) {
+			if (e.getCode() == HttpStatus.SC_UNPROCESSABLE_ENTITY) {
+				runsToPoll.remove(run);
+				logger.log(WARNING, "Cannot update status: {0}", e.getMessage());
+				return;
+			}
+			throw e;
+		}
+	}
 
-    private boolean shouldUpdateOpenShiftBuild(BuildCause cause,
-            int latestStageNum, int latestNumFlowNodes, StatusExt status) {
-        long currTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
-        logger.fine(String.format(
-                "shouldUpdateOpenShiftBuild curr time %s last update %s curr stage num %s last stage num %s"
-                        + "curr flow num %s last flow num %s status %s",
-                String.valueOf(currTime),
-                String.valueOf(cause.getLastUpdateToOpenshift()),
-                String.valueOf(latestStageNum),
-                String.valueOf(cause.getNumStages()),
-                String.valueOf(latestNumFlowNodes),
-                String.valueOf(cause.getNumFlowNodes()), status.toString()));
+	private boolean shouldUpdateOpenShiftBuild(BuildCause cause, int latestStageNum, int latestNumFlowNodes,
+			StatusExt status) {
+		long currTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+		logger.fine(String.format(
+				"shouldUpdateOpenShiftBuild curr time %s last update %s curr stage num %s last stage num %s"
+						+ "curr flow num %s last flow num %s status %s",
+				String.valueOf(currTime), String.valueOf(cause.getLastUpdateToOpenshift()),
+				String.valueOf(latestStageNum), String.valueOf(cause.getNumStages()),
+				String.valueOf(latestNumFlowNodes), String.valueOf(cause.getNumFlowNodes()), status.toString()));
 
-        // if we have not updated in maxDelay time, update
-        if (currTime > (cause.getLastUpdateToOpenshift() + maxDelay)) {
-            return true;
-        }
+		// if we have not updated in maxDelay time, update
+		if (currTime > (cause.getLastUpdateToOpenshift() + maxDelay)) {
+			return true;
+		}
 
-        // if the num of stages has changed, update
-        if (cause.getNumStages() != latestStageNum) {
-            return true;
-        }
+		// if the num of stages has changed, update
+		if (cause.getNumStages() != latestStageNum) {
+			return true;
+		}
 
-        // if the num of flow nodes has changed, update
-        if (cause.getNumFlowNodes() != latestNumFlowNodes) {
-            return true;
-        }
+		// if the num of flow nodes has changed, update
+		if (cause.getNumFlowNodes() != latestNumFlowNodes) {
+			return true;
+		}
 
-        // if the run is in some sort of terminal state, update
-        if (status != StatusExt.IN_PROGRESS) {
-            return true;
-        }
+		// if the run is in some sort of terminal state, update
+		if (status != StatusExt.IN_PROGRESS) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private void upsertBuild(Run run, RunExt wfRunExt) {
-        if (run == null) {
-            return;
-        }
+	private void upsertBuild(Run run, RunExt wfRunExt) {
+		if (run == null) {
+			return;
+		}
 
-        BuildCause cause = (BuildCause) run.getCause(BuildCause.class);
-        if (cause == null) {
-            return;
-        }
+		BuildCause cause = (BuildCause) run.getCause(BuildCause.class);
+		if (cause == null) {
+			return;
+		}
 
-        String rootUrl = OpenShiftUtils.getJenkinsURL(
-                getAuthenticatedOpenShiftClient(), cause.getNamespace());
-        String buildUrl = joinPaths(rootUrl, run.getUrl());
-        String logsUrl = joinPaths(buildUrl, "/consoleText");
-        String logsConsoleUrl = joinPaths(buildUrl, "/console");
-        String logsBlueOceanUrl = null;
-        try {
-            // there are utility functions in the blueocean-dashboard plugin
-            // which construct
-            // the entire blueocean URI; however, attempting to pull that in as
-            // a maven dependency was untenable from an injected test
-            // perspective;
-            // so we are leveraging reflection;
-            Jenkins jenkins = Jenkins.getInstance();
-            // NOTE, the excessive null checking is to keep `mvn findbugs:gui`
-            // quiet
-            if (jenkins != null) {
-                PluginManager pluginMgr = jenkins.getPluginManager();
-                if (pluginMgr != null) {
-                    ClassLoader cl = pluginMgr.uberClassLoader;
-                    if (cl != null) {
-                        Class weburlbldr = cl
-                                .loadClass("org.jenkinsci.plugins.blueoceandisplayurl.BlueOceanDisplayURLImpl");
-                        Constructor ctor = weburlbldr.getConstructor();
-                        Object displayURL = ctor.newInstance();
-                        Method getRunURLMethod = weburlbldr.getMethod(
-                                "getRunURL", hudson.model.Run.class);
-                        Object blueOceanURI = getRunURLMethod.invoke(
-                                displayURL, run);
-                        logsBlueOceanUrl = blueOceanURI.toString();
-                        logsBlueOceanUrl = logsBlueOceanUrl.replaceAll(
-                                "http://unconfigured-jenkins-location/", "");
-                        if (logsBlueOceanUrl.startsWith("http://")
-                                || logsBlueOceanUrl.startsWith("https://"))
-                            // still normalize string
-                            logsBlueOceanUrl = joinPaths("", logsBlueOceanUrl);
-                        else
-                            logsBlueOceanUrl = joinPaths(rootUrl,
-                                    logsBlueOceanUrl);
-                    }
-                }
-            }
-        } catch (Throwable t) {
-            if (logger.isLoggable(Level.FINE))
-                logger.log(Level.FINE, "upsertBuild", t);
-        }
+		String rootUrl = OpenShiftUtils.getJenkinsURL(getAuthenticatedOpenShiftClient(), cause.getNamespace());
+		String buildUrl = joinPaths(rootUrl, run.getUrl());
+		String logsUrl = joinPaths(buildUrl, "/consoleText");
+		String logsConsoleUrl = joinPaths(buildUrl, "/console");
+		String logsBlueOceanUrl = null;
+		try {
+			// there are utility functions in the blueocean-dashboard plugin
+			// which construct
+			// the entire blueocean URI; however, attempting to pull that in as
+			// a maven dependency was untenable from an injected test
+			// perspective;
+			// so we are leveraging reflection;
+			Jenkins jenkins = Jenkins.getInstance();
+			// NOTE, the excessive null checking is to keep `mvn findbugs:gui`
+			// quiet
+			if (jenkins != null) {
+				PluginManager pluginMgr = jenkins.getPluginManager();
+				if (pluginMgr != null) {
+					ClassLoader cl = pluginMgr.uberClassLoader;
+					if (cl != null) {
+						Class weburlbldr = cl
+								.loadClass("org.jenkinsci.plugins.blueoceandisplayurl.BlueOceanDisplayURLImpl");
+						Constructor ctor = weburlbldr.getConstructor();
+						Object displayURL = ctor.newInstance();
+						Method getRunURLMethod = weburlbldr.getMethod("getRunURL", hudson.model.Run.class);
+						Object blueOceanURI = getRunURLMethod.invoke(displayURL, run);
+						logsBlueOceanUrl = blueOceanURI.toString();
+						logsBlueOceanUrl = logsBlueOceanUrl.replaceAll("http://unconfigured-jenkins-location/", "");
+						if (logsBlueOceanUrl.startsWith("http://") || logsBlueOceanUrl.startsWith("https://"))
+							// still normalize string
+							logsBlueOceanUrl = joinPaths("", logsBlueOceanUrl);
+						else
+							logsBlueOceanUrl = joinPaths(rootUrl, logsBlueOceanUrl);
+					}
+				}
+			}
+		} catch (Throwable t) {
+			if (logger.isLoggable(Level.FINE))
+				logger.log(Level.FINE, "upsertBuild", t);
+		}
 
-        boolean pendingInput = false;
-        if (!wfRunExt.get_links().self.href.matches("^https?://.*$")) {
-            wfRunExt.get_links().self.setHref(joinPaths(rootUrl,
-                    wfRunExt.get_links().self.href));
-        }
-        int newNumStages = wfRunExt.getStages().size();
-        int newNumFlowNodes = 0;
-        for (StageNodeExt stage : wfRunExt.getStages()) {
-            FlowNodeExt.FlowNodeLinks links = stage.get_links();
-            if (!links.self.href.matches("^https?://.*$")) {
-                links.self.setHref(joinPaths(rootUrl, links.self.href));
-            }
-            if (links.getLog() != null
-                    && !links.getLog().href.matches("^https?://.*$")) {
-                links.getLog().setHref(joinPaths(rootUrl, links.getLog().href));
-            }
-            newNumFlowNodes = newNumFlowNodes
-                    + stage.getStageFlowNodes().size();
-            for (AtomFlowNodeExt node : stage.getStageFlowNodes()) {
-                FlowNodeExt.FlowNodeLinks nodeLinks = node.get_links();
-                if (!nodeLinks.self.href.matches("^https?://.*$")) {
-                    nodeLinks.self.setHref(joinPaths(rootUrl,
-                            nodeLinks.self.href));
-                }
-                if (nodeLinks.getLog() != null
-                        && !nodeLinks.getLog().href.matches("^https?://.*$")) {
-                    nodeLinks.getLog().setHref(
-                            joinPaths(rootUrl, nodeLinks.getLog().href));
-                }
-            }
+		boolean pendingInput = false;
+		if (!wfRunExt.get_links().self.href.matches("^https?://.*$")) {
+			wfRunExt.get_links().self.setHref(joinPaths(rootUrl, wfRunExt.get_links().self.href));
+		}
+		int newNumStages = wfRunExt.getStages().size();
+		int newNumFlowNodes = 0;
+		for (StageNodeExt stage : wfRunExt.getStages()) {
+			FlowNodeExt.FlowNodeLinks links = stage.get_links();
+			if (!links.self.href.matches("^https?://.*$")) {
+				links.self.setHref(joinPaths(rootUrl, links.self.href));
+			}
+			if (links.getLog() != null && !links.getLog().href.matches("^https?://.*$")) {
+				links.getLog().setHref(joinPaths(rootUrl, links.getLog().href));
+			}
+			newNumFlowNodes = newNumFlowNodes + stage.getStageFlowNodes().size();
+			for (AtomFlowNodeExt node : stage.getStageFlowNodes()) {
+				FlowNodeExt.FlowNodeLinks nodeLinks = node.get_links();
+				if (!nodeLinks.self.href.matches("^https?://.*$")) {
+					nodeLinks.self.setHref(joinPaths(rootUrl, nodeLinks.self.href));
+				}
+				if (nodeLinks.getLog() != null && !nodeLinks.getLog().href.matches("^https?://.*$")) {
+					nodeLinks.getLog().setHref(joinPaths(rootUrl, nodeLinks.getLog().href));
+				}
+			}
 
-            StatusExt status = stage.getStatus();
-            if (status != null && status.equals(StatusExt.PAUSED_PENDING_INPUT)) {
-              pendingInput = true;
-            }
-        }
+			StatusExt status = stage.getStatus();
+			if (status != null && status.equals(StatusExt.PAUSED_PENDING_INPUT)) {
+				pendingInput = true;
+			}
+		}
 
-        boolean needToUpdate = this.shouldUpdateOpenShiftBuild(cause,
-                newNumStages, newNumFlowNodes, wfRunExt.getStatus());
-        if (!needToUpdate) {
-            return;
-        }
+		boolean needToUpdate = this.shouldUpdateOpenShiftBuild(cause, newNumStages, newNumFlowNodes,
+				wfRunExt.getStatus());
+		if (!needToUpdate) {
+			return;
+		}
 
-        String json;
-        try {
-            json = new ObjectMapper().writeValueAsString(wfRunExt);
-        } catch (JsonProcessingException e) {
-            logger.log(SEVERE, "Failed to serialize workflow run. " + e, e);
-            return;
-        }
+		String json;
+		try {
+			json = new ObjectMapper().writeValueAsString(wfRunExt);
+		} catch (JsonProcessingException e) {
+			logger.log(SEVERE, "Failed to serialize workflow run. " + e, e);
+			return;
+		}
 
-        String pendingActionsJson = null;
-        if (pendingInput && run instanceof WorkflowRun) {
-            pendingActionsJson = getPendingActionsJson((WorkflowRun) run);
-        }
+		String pendingActionsJson = null;
+		if (pendingInput && run instanceof WorkflowRun) {
+			pendingActionsJson = getPendingActionsJson((WorkflowRun) run);
+		}
 
-        String phase = runToBuildPhase(run);
+		String phase = runToBuildPhase(run);
 
-        long started = getStartTime(run);
-        String startTime = null;
-        String completionTime = null;
-        if (started > 0) {
-            startTime = formatTimestamp(started);
+		long started = getStartTime(run);
+		String startTime = null;
+		String completionTime = null;
+		if (started > 0) {
+			startTime = formatTimestamp(started);
 
-            long duration = getDuration(run);
-            if (duration > 0) {
-                completionTime = formatTimestamp(started + duration);
-            }
-        }
+			long duration = getDuration(run);
+			if (duration > 0) {
+				completionTime = formatTimestamp(started + duration);
+			}
+		}
 
-        logger.log(FINE, "Patching build {0}/{1}: setting phase to {2}",
-                new Object[] { cause.getNamespace(), cause.getName(), phase });
-        try {
-            BuildFluent.MetadataNested<DoneableBuild> builder = getAuthenticatedOpenShiftClient()
-                    .builds()
-                    .inNamespace(cause.getNamespace())
-                    .withName(cause.getName())
-                    .edit()
-                    .editMetadata()
-                    .addToAnnotations(
-                            OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON, json)
-                    .addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI,
-                            buildUrl)
-                    .addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL,
-                            logsUrl)
-                    .addToAnnotations(
-                            Constants.OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL,
-                            logsConsoleUrl)
-                    .addToAnnotations(
-                            Constants.OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL,
-                            logsBlueOceanUrl);
+		logger.log(FINE, "Patching build {0}/{1}: setting phase to {2}",
+				new Object[] { cause.getNamespace(), cause.getName(), phase });
+		try {
+			BuildFluent.MetadataNested<DoneableBuild> builder = getAuthenticatedOpenShiftClient().builds()
+					.inNamespace(cause.getNamespace()).withName(cause.getName()).edit().editMetadata()
+					.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON, json)
+					.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI, buildUrl)
+					.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL, logsUrl)
+					.addToAnnotations(Constants.OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL, logsConsoleUrl)
+					.addToAnnotations(Constants.OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL, logsBlueOceanUrl);
 
-            String jenkinsNamespace = System.getenv("KUBERNETES_NAMESPACE");
-            if (jenkinsNamespace != null && !jenkinsNamespace.isEmpty()) {
-                builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE, jenkinsNamespace);
-            }
-            if (pendingActionsJson != null && !pendingActionsJson.isEmpty()) {
-                builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON, pendingActionsJson);
-            }
-            builder
-              .endMetadata()
-              .editStatus()
-              .withPhase(phase)
-              .withStartTimestamp(startTime)
-              .withCompletionTimestamp(completionTime)
-              .endStatus()
-              .done();
-        } catch (KubernetesClientException e) {
-            if (HTTP_NOT_FOUND == e.getCode()) {
-                runsToPoll.remove(run);
-            } else {
-                throw e;
-            }
-        }
+			String jenkinsNamespace = System.getenv("KUBERNETES_NAMESPACE");
+			if (jenkinsNamespace != null && !jenkinsNamespace.isEmpty()) {
+				builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE, jenkinsNamespace);
+			}
+			if (pendingActionsJson != null && !pendingActionsJson.isEmpty()) {
+				builder.addToAnnotations(OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON, pendingActionsJson);
+			}
+			builder.endMetadata().editStatus().withPhase(phase).withStartTimestamp(startTime)
+					.withCompletionTimestamp(completionTime).endStatus().done();
+		} catch (KubernetesClientException e) {
+			if (HTTP_NOT_FOUND == e.getCode()) {
+				runsToPoll.remove(run);
+			} else {
+				throw e;
+			}
+		}
 
-        cause.setNumFlowNodes(newNumFlowNodes);
-        cause.setNumStages(newNumStages);
-        cause.setLastUpdateToOpenshift(TimeUnit.NANOSECONDS.toMillis(System
-                .nanoTime()));
-    }
+		cause.setNumFlowNodes(newNumFlowNodes);
+		cause.setNumStages(newNumStages);
+		cause.setLastUpdateToOpenshift(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
+	}
 
-    //annotate the Build with pending input JSON so consoles can do the Proceed/Abort stuff if they want
-    private String getPendingActionsJson(WorkflowRun run) {
-        List<PendingInputActionsExt> pendingInputActions = new ArrayList<PendingInputActionsExt>();
-        InputAction inputAction = run.getAction(InputAction.class);
+	// annotate the Build with pending input JSON so consoles can do the
+	// Proceed/Abort stuff if they want
+	private String getPendingActionsJson(WorkflowRun run) {
+		List<PendingInputActionsExt> pendingInputActions = new ArrayList<PendingInputActionsExt>();
+		InputAction inputAction = run.getAction(InputAction.class);
 
-        if (inputAction != null) {
-            List<InputStepExecution> executions = inputAction.getExecutions();
-            if (executions != null && !executions.isEmpty()) {
-                for (InputStepExecution inputStepExecution : executions) {
-                    pendingInputActions.add(PendingInputActionsExt.create(inputStepExecution, run));
-                }
-            }
-        }
-        try {
-            return new ObjectMapper().writeValueAsString(pendingInputActions);
-        } catch (JsonProcessingException e) {
-            logger.log(SEVERE, "Failed to serialize pending actions. " + e, e);
-            return null;
-        }
-    }
+		if (inputAction != null) {
+			List<InputStepExecution> executions = inputAction.getExecutions();
+			if (executions != null && !executions.isEmpty()) {
+				for (InputStepExecution inputStepExecution : executions) {
+					pendingInputActions.add(PendingInputActionsExt.create(inputStepExecution, run));
+				}
+			}
+		}
+		try {
+			return new ObjectMapper().writeValueAsString(pendingInputActions);
+		} catch (JsonProcessingException e) {
+			logger.log(SEVERE, "Failed to serialize pending actions. " + e, e);
+			return null;
+		}
+	}
 
-    private long getStartTime(Run run) {
-        return run.getStartTimeInMillis();
-    }
+	private long getStartTime(Run run) {
+		return run.getStartTimeInMillis();
+	}
 
-    private long getDuration(Run run) {
-        return run.getDuration();
-    }
+	private long getDuration(Run run) {
+		return run.getDuration();
+	}
 
-    private String runToBuildPhase(Run run) {
-        if (run != null && !run.hasntStartedYet()) {
-            if (run.isBuilding()) {
-                return BuildPhases.RUNNING;
-            } else {
-                Result result = run.getResult();
-                if (result != null) {
-                    if (result.equals(Result.SUCCESS)) {
-                        return BuildPhases.COMPLETE;
-                    } else if (result.equals(Result.ABORTED)) {
-                        return BuildPhases.CANCELLED;
-                    } else if (result.equals(Result.FAILURE)) {
-                        return BuildPhases.FAILED;
-                    } else if (result.equals(Result.UNSTABLE)) {
-                        return BuildPhases.FAILED;
-                    } else {
-                        return BuildPhases.PENDING;
-                    }
-                }
-            }
-        }
-        return BuildPhases.NEW;
-    }
+	private String runToBuildPhase(Run run) {
+		if (run != null && !run.hasntStartedYet()) {
+			if (run.isBuilding()) {
+				return BuildPhases.RUNNING;
+			} else {
+				Result result = run.getResult();
+				if (result != null) {
+					if (result.equals(Result.SUCCESS)) {
+						return BuildPhases.COMPLETE;
+					} else if (result.equals(Result.ABORTED)) {
+						return BuildPhases.CANCELLED;
+					} else if (result.equals(Result.FAILURE)) {
+						return BuildPhases.FAILED;
+					} else if (result.equals(Result.UNSTABLE)) {
+						return BuildPhases.FAILED;
+					} else {
+						return BuildPhases.PENDING;
+					}
+				}
+			}
+		}
+		return BuildPhases.NEW;
+	}
 
-    /**
-     * Returns true if we should poll the status of this run
-     *
-     * @param run
-     *            the Run to test against
-     * @return true if the should poll the status of this build run
-     */
-    protected boolean shouldPollRun(Run run) {
-        return run instanceof WorkflowRun
-                && run.getCause(BuildCause.class) != null &&
-                GlobalPluginConfiguration.get().isEnabled();
-    }
+	/**
+	 * Returns true if we should poll the status of this run
+	 *
+	 * @param run
+	 *            the Run to test against
+	 * @return true if the should poll the status of this build run
+	 */
+	protected boolean shouldPollRun(Run run) {
+		return run instanceof WorkflowRun && run.getCause(BuildCause.class) != null
+				&& GlobalPluginConfiguration.get().isEnabled();
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -25,8 +25,11 @@ public class Constants {
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
+  public static final String OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON = "openshift.io/jenkins-pending-input-actions-json";
+
 
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
+  public static final String OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE = "openshift.io/jenkins-namespace";
   public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
 
   public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -18,24 +18,24 @@ package io.fabric8.jenkins.openshiftsync;
 /**
  */
 public class Constants {
-    public static final String OPENSHIFT_DEFAULT_NAMESPACE = "default";
+	public static final String OPENSHIFT_DEFAULT_NAMESPACE = "default";
 
-    public static final String OPENSHIFT_ANNOTATIONS_BUILD_NUMBER = "openshift.io/build.number";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI = "openshift.io/jenkins-build-uri";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON = "openshift.io/jenkins-pending-input-actions-json";
+	public static final String OPENSHIFT_ANNOTATIONS_BUILD_NUMBER = "openshift.io/build.number";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI = "openshift.io/jenkins-build-uri";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON = "openshift.io/jenkins-pending-input-actions-json";
 
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
-    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE = "openshift.io/jenkins-namespace";
-    public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
+	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE = "openshift.io/jenkins-namespace";
+	public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
 
-    public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
-    public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
-    public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
-    public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
-    public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
-    public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";
-    public static final String OPENSHIFT_BUILD_STATUS_FIELD = "status";
+	public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
+	public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
+	public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
+	public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
+	public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
+	public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";
+	public static final String OPENSHIFT_BUILD_STATUS_FIELD = "status";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -29,182 +29,156 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 public class CredentialsUtils {
 
-    private final static Logger logger = Logger
-            .getLogger(CredentialsUtils.class.getName());
+	private final static Logger logger = Logger.getLogger(CredentialsUtils.class.getName());
 
-    public static synchronized String updateSourceCredentials(
-            BuildConfig buildConfig) throws IOException {
-        if (buildConfig.getSpec() != null
-                && buildConfig.getSpec().getSource() != null
-                && buildConfig.getSpec().getSource().getSourceSecret() != null
-                && !buildConfig.getSpec().getSource().getSourceSecret()
-                        .getName().isEmpty()) {
-          String secretName = buildConfig.getSpec().getSource().getSourceSecret().getName();
-          String namespace = buildConfig.getMetadata().getNamespace();
-          Secret sourceSecret = getAuthenticatedOpenShiftClient()
-                    .secrets()
-                    .inNamespace(buildConfig.getMetadata().getNamespace())
-                    .withName(
-                            buildConfig.getSpec().getSource().getSourceSecret()
-                                    .getName()).get();
-            return upsertCredential(sourceSecret, namespace, secretName);
+	public static synchronized String updateSourceCredentials(BuildConfig buildConfig) throws IOException {
+		if (buildConfig.getSpec() != null && buildConfig.getSpec().getSource() != null
+				&& buildConfig.getSpec().getSource().getSourceSecret() != null
+				&& !buildConfig.getSpec().getSource().getSourceSecret().getName().isEmpty()) {
+			String secretName = buildConfig.getSpec().getSource().getSourceSecret().getName();
+			String namespace = buildConfig.getMetadata().getNamespace();
+			Secret sourceSecret = getAuthenticatedOpenShiftClient().secrets()
+					.inNamespace(buildConfig.getMetadata().getNamespace())
+					.withName(buildConfig.getSpec().getSource().getSourceSecret().getName()).get();
+			return upsertCredential(sourceSecret, namespace, secretName);
 
-        }
-        return null;
-    }
+		}
+		return null;
+	}
 
-    /**
-     * Inserts or creates a Jenkins Credential for the given Secret
-     */
-    public static synchronized String upsertCredential(Secret secret) throws IOException {
-      if (secret != null) {
-        ObjectMeta metadata = secret.getMetadata();
-        if (metadata != null){
-          return upsertCredential(secret, metadata.getNamespace(), metadata.getName());
-        }
-      }
-      return null;
-    }
+	/**
+	 * Inserts or creates a Jenkins Credential for the given Secret
+	 */
+	public static synchronized String upsertCredential(Secret secret) throws IOException {
+		if (secret != null) {
+			ObjectMeta metadata = secret.getMetadata();
+			if (metadata != null) {
+				return upsertCredential(secret, metadata.getNamespace(), metadata.getName());
+			}
+		}
+		return null;
+	}
 
-    private static String upsertCredential(Secret secret, String namespace, String secretName) throws IOException {
-      String id = null;
-      if (secret != null) {
-        Credentials creds = secretToCredentials(secret);
-        id = secretName(namespace, secretName);
-        Credentials existingCreds = lookupCredentials(id);
-        final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
-        try {
-          CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getActiveInstance()).iterator().next();
-          if (existingCreds != null) {
-            s.updateCredentials(Domain.global(), existingCreds, creds);
-          } else {
-            s.addCredentials(Domain.global(), creds);
-          }
-        } finally {
-          SecurityContextHolder.setContext(previousContext);
-        }
-      }
-      return id;
-    }
+	private static String upsertCredential(Secret secret, String namespace, String secretName) throws IOException {
+		String id = null;
+		if (secret != null) {
+			Credentials creds = secretToCredentials(secret);
+			id = secretName(namespace, secretName);
+			Credentials existingCreds = lookupCredentials(id);
+			final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
+			try {
+				CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getActiveInstance()).iterator().next();
+				if (existingCreds != null) {
+					s.updateCredentials(Domain.global(), existingCreds, creds);
+				} else {
+					s.addCredentials(Domain.global(), creds);
+				}
+			} finally {
+				SecurityContextHolder.setContext(previousContext);
+			}
+		}
+		return id;
+	}
 
-    // getCurrentToken returns the ServiceAccount token currently selected by
-    // the user. A return value of empty string
-    // implies no token is configured.
-    public static String getCurrentToken() {
-        String credentialsId = GlobalPluginConfiguration.get()
-                .getCredentialsId();
-        if (credentialsId.equals("")) {
-            return "";
-        }
+	// getCurrentToken returns the ServiceAccount token currently selected by
+	// the user. A return value of empty string
+	// implies no token is configured.
+	public static String getCurrentToken() {
+		String credentialsId = GlobalPluginConfiguration.get().getCredentialsId();
+		if (credentialsId.equals("")) {
+			return "";
+		}
 
-        OpenShiftToken token = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(OpenShiftToken.class,
-                        Jenkins.getActiveInstance(), ACL.SYSTEM,
-                        Collections.<DomainRequirement> emptyList()),
-                CredentialsMatchers.withId(credentialsId));
+		OpenShiftToken token = CredentialsMatchers
+				.firstOrNull(
+						CredentialsProvider.lookupCredentials(OpenShiftToken.class, Jenkins.getActiveInstance(),
+								ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+						CredentialsMatchers.withId(credentialsId));
 
-        if (token != null) {
-            return token.getToken();
-        }
+		if (token != null) {
+			return token.getToken();
+		}
 
-        return "";
-    }
+		return "";
+	}
 
-    private static Credentials lookupCredentials(String id) {
-      return CredentialsMatchers.firstOrNull(
-        CredentialsProvider.lookupCredentials(
-          Credentials.class,
-          Jenkins.getActiveInstance(),
-          ACL.SYSTEM,
-          Collections.<DomainRequirement> emptyList()
-        ),
-        CredentialsMatchers.withId(id)
-      );
-    }
+	private static Credentials lookupCredentials(String id) {
+		return CredentialsMatchers
+				.firstOrNull(
+						CredentialsProvider.lookupCredentials(Credentials.class, Jenkins.getActiveInstance(),
+								ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+						CredentialsMatchers.withId(id));
+	}
 
-  private static String secretName(String namespace, String name) {
-    String watchNamespace = null;
-    GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
-    if (config != null) {
-      watchNamespace = config.getNamespace();
-    }
-    // if we only watch a single namespace and this secret is in that namespace then
-    // lets avoid the namespace prefix in the name
-    if (watchNamespace != null && namespace.equals(watchNamespace)) {
-      return name;
-    }
-    return namespace + "-" + name;
-  }
+	private static String secretName(String namespace, String name) {
+		String watchNamespace = null;
+		GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
+		if (config != null) {
+			watchNamespace = config.getNamespace();
+		}
+		// if we only watch a single namespace and this secret is in that namespace then
+		// lets avoid the namespace prefix in the name
+		if (watchNamespace != null && namespace.equals(watchNamespace)) {
+			return name;
+		}
+		return namespace + "-" + name;
+	}
 
-  private static Credentials secretToCredentials(Secret secret) {
-    String namespace = secret.getMetadata().getNamespace();
-    String name = secret.getMetadata().getName();
-    final Map<String, String> data = secret.getData();
-    final String secretName = secretName(namespace, name);
-    switch (secret.getType()) {
-      case OPENSHIFT_SECRETS_TYPE_OPAQUE:
-        String usernameData = data.get(OPENSHIFT_SECRETS_DATA_USERNAME);
-        String passwordData = data.get(OPENSHIFT_SECRETS_DATA_PASSWORD);
-        if (isNotBlank(usernameData) && isNotBlank(passwordData)) {
-          return newUsernamePasswordCredentials(
-            secretName,
-            usernameData,
-            passwordData
-          );
-        }
-        String sshKeyData = data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY);
-        if (isNotBlank(sshKeyData)) {
-            return newSSHUserCredential(secretName,
-                    data.get(OPENSHIFT_SECRETS_DATA_USERNAME), sshKeyData);
-        }
+	private static Credentials secretToCredentials(Secret secret) {
+		String namespace = secret.getMetadata().getNamespace();
+		String name = secret.getMetadata().getName();
+		final Map<String, String> data = secret.getData();
+		final String secretName = secretName(namespace, name);
+		switch (secret.getType()) {
+		case OPENSHIFT_SECRETS_TYPE_OPAQUE:
+			String usernameData = data.get(OPENSHIFT_SECRETS_DATA_USERNAME);
+			String passwordData = data.get(OPENSHIFT_SECRETS_DATA_PASSWORD);
+			if (isNotBlank(usernameData) && isNotBlank(passwordData)) {
+				return newUsernamePasswordCredentials(secretName, usernameData, passwordData);
+			}
+			String sshKeyData = data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY);
+			if (isNotBlank(sshKeyData)) {
+				return newSSHUserCredential(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME), sshKeyData);
+			}
 
-        logger.log(
-                Level.WARNING,
-                "Opaque secret either requires {0} and {1} fields for basic auth or {2} field for SSH key",
-                new Object[] { OPENSHIFT_SECRETS_DATA_USERNAME,
-                        OPENSHIFT_SECRETS_DATA_PASSWORD,
-                        OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY });
-        return null;
-      case OPENSHIFT_SECRETS_TYPE_BASICAUTH:
-          return newUsernamePasswordCredentials(secretName,
-                  data.get(OPENSHIFT_SECRETS_DATA_USERNAME),
-                  data.get(OPENSHIFT_SECRETS_DATA_PASSWORD));
-      case OPENSHIFT_SECRETS_TYPE_SSH:
-          return newSSHUserCredential(secretName,
-                  data.get(OPENSHIFT_SECRETS_DATA_USERNAME),
-                  data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY));
-      default:
-          logger.log(Level.WARNING,
-                  "Unknown secret type: " + secret.getType());
-          return null;
-        }
-    }
+			logger.log(Level.WARNING,
+					"Opaque secret either requires {0} and {1} fields for basic auth or {2} field for SSH key",
+					new Object[] { OPENSHIFT_SECRETS_DATA_USERNAME, OPENSHIFT_SECRETS_DATA_PASSWORD,
+							OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY });
+			return null;
+		case OPENSHIFT_SECRETS_TYPE_BASICAUTH:
+			return newUsernamePasswordCredentials(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME),
+					data.get(OPENSHIFT_SECRETS_DATA_PASSWORD));
+		case OPENSHIFT_SECRETS_TYPE_SSH:
+			return newSSHUserCredential(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME),
+					data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY));
+		default:
+			logger.log(Level.WARNING, "Unknown secret type: " + secret.getType());
+			return null;
+		}
+	}
 
-    private static Credentials newSSHUserCredential(String secretName,
-            String username, String sshKeyData) {
-        return new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, secretName,
-                fixNull(username),
-                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
-                        new String(Base64.decode(sshKeyData),
-                                StandardCharsets.UTF_8)), null, secretName);
-    }
+	private static Credentials newSSHUserCredential(String secretName, String username, String sshKeyData) {
+		return new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, secretName, fixNull(username),
+				new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
+						new String(Base64.decode(sshKeyData), StandardCharsets.UTF_8)),
+				null, secretName);
+	}
 
-    private static Credentials newUsernamePasswordCredentials(
-            String secretName, String usernameData, String passwordData) {
-        return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
-                secretName, secretName, new String(Base64.decode(usernameData),
-                        StandardCharsets.UTF_8), new String(
-                        Base64.decode(passwordData), StandardCharsets.UTF_8));
-    }
+	private static Credentials newUsernamePasswordCredentials(String secretName, String usernameData,
+			String passwordData) {
+		return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName,
+				new String(Base64.decode(usernameData), StandardCharsets.UTF_8),
+				new String(Base64.decode(passwordData), StandardCharsets.UTF_8));
+	}
 
-    /**
-     * Does our configuration have credentials?
-     * 
-     * @return true if found.
-     */
-    public static boolean hasCredentials() {
-        return !StringUtils.isEmpty(getAuthenticatedOpenShiftClient()
-                .getConfiguration().getOauthToken());
-    }
+	/**
+	 * Does our configuration have credentials?
+	 * 
+	 * @return true if found.
+	 */
+	public static boolean hasCredentials() {
+		return !StringUtils.isEmpty(getAuthenticatedOpenShiftClient().getConfiguration().getOauthToken());
+	}
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -111,16 +111,6 @@ public class CredentialsUtils {
 	}
 
 	private static String secretName(String namespace, String name) {
-		String watchNamespace = null;
-		GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
-		if (config != null) {
-			watchNamespace = config.getNamespace();
-		}
-		// if we only watch a single namespace and this secret is in that namespace then
-		// lets avoid the namespace prefix in the name
-		if (watchNamespace != null && namespace.equals(watchNamespace)) {
-			return name;
-		}
 		return namespace + "-" + name;
 	}
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -32,9 +32,7 @@ public class CredentialsUtils {
   private final static Logger logger = Logger.getLogger(CredentialsUtils.class.getName());
 
   public static synchronized String updateSourceCredentials(BuildConfig buildConfig) throws IOException {
-    if (buildConfig.getSpec() != null &&
-            buildConfig.getSpec().getSource() != null &&
-            buildConfig.getSpec().getSource().getSourceSecret() != null) {
+    if (buildConfig.getSpec() != null && buildConfig.getSpec().getSource() != null && buildConfig.getSpec().getSource().getSourceSecret() != null) {
       String secretName = buildConfig.getSpec().getSource().getSourceSecret().getName();
       String namespace = buildConfig.getMetadata().getNamespace();
       if (!secretName.isEmpty()) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -41,223 +41,208 @@ import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient
 @Extension
 public class GlobalPluginConfiguration extends GlobalConfiguration {
 
-    private static final Logger logger = Logger
-            .getLogger(GlobalPluginConfiguration.class.getName());
+	private static final Logger logger = Logger.getLogger(GlobalPluginConfiguration.class.getName());
 
-    private boolean enabled = true;
+	private boolean enabled = true;
 
-    private String server;
+	private String server;
 
-    private String credentialsId = "";
+	private String credentialsId = "";
 
-    private String[] namespaces;
+	private String[] namespaces;
 
-    private String jobNamePattern;
+	private String jobNamePattern;
 
-    private String skipOrganizationPrefix;
+	private String skipOrganizationPrefix;
 
-    private String skipBranchSuffix;
+	private String skipBranchSuffix;
 
-    private transient BuildWatcher buildWatcher;
+	private transient BuildWatcher buildWatcher;
 
-    private transient BuildConfigWatcher buildConfigWatcher;
+	private transient BuildConfigWatcher buildConfigWatcher;
 
-    private transient SecretWatcher secretWatcher;
+	private transient SecretWatcher secretWatcher;
 
-    private transient ConfigMapWatcher configMapWatcher;
+	private transient ConfigMapWatcher configMapWatcher;
 
-    private transient ImageStreamWatcher imageStreamWatcher;
+	private transient ImageStreamWatcher imageStreamWatcher;
 
-    @DataBoundConstructor
-    public GlobalPluginConfiguration(boolean enable, String server,
-                                     String namespace, String credentialsId, String jobNamePattern,
-                                     String skipOrganizationPrefix, String skipBranchSuffix) {
-        this.enabled = enable;
-        this.server = server;
-        this.namespaces = StringUtils.isBlank(namespace) ? null : namespace
-                .split(" ");
-        this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
-        this.jobNamePattern = jobNamePattern;
-        this.skipOrganizationPrefix = skipOrganizationPrefix;
-        this.skipBranchSuffix = skipBranchSuffix;
-        configChange();
-    }
+	@DataBoundConstructor
+	public GlobalPluginConfiguration(boolean enable, String server, String namespace, String credentialsId,
+			String jobNamePattern, String skipOrganizationPrefix, String skipBranchSuffix) {
+		this.enabled = enable;
+		this.server = server;
+		this.namespaces = StringUtils.isBlank(namespace) ? null : namespace.split(" ");
+		this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
+		this.jobNamePattern = jobNamePattern;
+		this.skipOrganizationPrefix = skipOrganizationPrefix;
+		this.skipBranchSuffix = skipBranchSuffix;
+		configChange();
+	}
 
-    public GlobalPluginConfiguration() {
-        load();
-        configChange();
-        save();
-    }
+	public GlobalPluginConfiguration() {
+		load();
+		configChange();
+		save();
+	}
 
-    public static GlobalPluginConfiguration get() {
-        return GlobalConfiguration.all().get(GlobalPluginConfiguration.class);
-    }
+	public static GlobalPluginConfiguration get() {
+		return GlobalConfiguration.all().get(GlobalPluginConfiguration.class);
+	}
 
-    @Override
-    public String getDisplayName() {
-        return "OpenShift Jenkins Sync";
-    }
+	@Override
+	public String getDisplayName() {
+		return "OpenShift Jenkins Sync";
+	}
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json)
-            throws hudson.model.Descriptor.FormException {
-        req.bindJSON(this, json);
-        configChange();
-        save();
-        return true;
-    }
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
+		req.bindJSON(this, json);
+		configChange();
+		save();
+		return true;
+	}
 
-    public boolean isEnabled() {
-        return enabled;
-    }
+	public boolean isEnabled() {
+		return enabled;
+	}
 
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 
-    public String getServer() {
-        return server;
-    }
+	public String getServer() {
+		return server;
+	}
 
-    public void setServer(String server) {
-        this.server = server;
-    }
+	public void setServer(String server) {
+		this.server = server;
+	}
 
-    // When Jenkins is reset, credentialsId is strangely set to null. However,
-    // credentialsId has no reason to be null.
-    public String getCredentialsId() {
-        return credentialsId == null ? "" : credentialsId;
-    }
+	// When Jenkins is reset, credentialsId is strangely set to null. However,
+	// credentialsId has no reason to be null.
+	public String getCredentialsId() {
+		return credentialsId == null ? "" : credentialsId;
+	}
 
-    public void setCredentialsId(String credentialsId) {
-        this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
-    }
+	public void setCredentialsId(String credentialsId) {
+		this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
+	}
 
-    public String getNamespace() {
-        return namespaces == null ? "" : StringUtils.join(namespaces, " ");
-    }
+	public String getNamespace() {
+		return namespaces == null ? "" : StringUtils.join(namespaces, " ");
+	}
 
-    public void setNamespace(String namespace) {
-        this.namespaces = StringUtils.isBlank(namespace) ? null : namespace
-                .split(" ");
-    }
+	public void setNamespace(String namespace) {
+		this.namespaces = StringUtils.isBlank(namespace) ? null : namespace.split(" ");
+	}
 
+	public String getJobNamePattern() {
+		return jobNamePattern;
+	}
 
+	public void setJobNamePattern(String jobNamePattern) {
+		this.jobNamePattern = jobNamePattern;
+	}
 
-  public String getJobNamePattern() {
-      return jobNamePattern;
-  }
+	public String getSkipOrganizationPrefix() {
+		return skipOrganizationPrefix;
+	}
 
-  public void setJobNamePattern(String jobNamePattern) {
-      this.jobNamePattern = jobNamePattern;
-  }
+	public void setSkipOrganizationPrefix(String skipOrganizationPrefix) {
+		this.skipOrganizationPrefix = skipOrganizationPrefix;
+	}
 
-  public String getSkipOrganizationPrefix() {
-      return skipOrganizationPrefix;
-  }
+	public String getSkipBranchSuffix() {
+		return skipBranchSuffix;
+	}
 
-  public void setSkipOrganizationPrefix(String skipOrganizationPrefix) {
-    this.skipOrganizationPrefix = skipOrganizationPrefix;
-  }
+	public void setSkipBranchSuffix(String skipBranchSuffix) {
+		this.skipBranchSuffix = skipBranchSuffix;
+	}
 
-  public String getSkipBranchSuffix() {
-      return skipBranchSuffix;
-  }
+	// https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
+	// http://javadoc.jenkins-ci.org/credentials/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.html
+	// https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
+	public static ListBoxModel doFillCredentialsIdItems(String credentialsId) {
+		Jenkins jenkins = Jenkins.getInstance();
+		if (jenkins == null) {
+			return (ListBoxModel) null;
+		}
 
-  public void setSkipBranchSuffix(String skipBranchSuffix) {
-      this.skipBranchSuffix = skipBranchSuffix;
-  }
+		if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+			// Important! Otherwise you expose credentials metadata to random
+			// web requests.
+			return new StandardListBoxModel().includeCurrentValue(credentialsId);
+		}
 
-  // https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
-  // http://javadoc.jenkins-ci.org/credentials/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.html
-  // https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
-  public static ListBoxModel doFillCredentialsIdItems(String credentialsId) {
-      Jenkins jenkins = Jenkins.getInstance();
-      if (jenkins == null) {
-        return (ListBoxModel) null;
-      }
+		return new StandardListBoxModel().includeEmptyValue().includeAs(ACL.SYSTEM, jenkins, OpenShiftToken.class)
+				.includeCurrentValue(credentialsId);
+	}
 
-      if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
-        // Important! Otherwise you expose credentials metadata to random
-        // web requests.
-        return new StandardListBoxModel()
-            .includeCurrentValue(credentialsId);
-      }
+	private void configChange() {
+		if (!enabled) {
+			if (buildConfigWatcher != null) {
+				buildConfigWatcher.stop();
+			}
+			if (buildWatcher != null) {
+				buildWatcher.stop();
+			}
+			if (configMapWatcher != null) {
+				configMapWatcher.stop();
+			}
+			if (imageStreamWatcher != null) {
+				imageStreamWatcher.stop();
+			}
+			OpenShiftUtils.shutdownOpenShiftClient();
+			return;
+		}
+		try {
+			OpenShiftUtils.initializeOpenShiftClient(server);
+			this.namespaces = getNamespaceOrUseDefault(namespaces, getOpenShiftClient());
 
-      return new StandardListBoxModel().includeEmptyValue()
-        .includeAs(ACL.SYSTEM, jenkins, OpenShiftToken.class)
-        .includeCurrentValue(credentialsId);
-  }
+			Runnable task = new SafeTimerTask() {
+				@Override
+				protected void doRun() throws Exception {
+					logger.info("Waiting for Jenkins to be started");
+					while (true) {
+						final Jenkins instance = Jenkins.getActiveInstance();
+						// We can look at Jenkins Init Level to see if we are
+						// ready
+						// to start. If we do not wait, we risk the chance of a
+						// deadlock.
+						//
+						InitMilestone initLevel = instance.getInitLevel();
+						logger.fine("Jenkins init level: " + initLevel.toString());
+						if (initLevel == InitMilestone.COMPLETED) {
+							break;
+						}
+						logger.fine("Jenkins not ready...");
+						try {
+							Thread.sleep(500);
+						} catch (InterruptedException e) {
+							// ignore
+						}
+					}
 
-  private void configChange() {
-      if (!enabled) {
-          if (buildConfigWatcher != null) {
-              buildConfigWatcher.stop();
-          }
-          if (buildWatcher != null) {
-              buildWatcher.stop();
-          }
-          if (configMapWatcher != null) {
-              configMapWatcher.stop();
-          }
-          if (imageStreamWatcher != null) {
-              imageStreamWatcher.stop();
-          }
-          OpenShiftUtils.shutdownOpenShiftClient();
-          return;
-      }
-      try {
-          OpenShiftUtils.initializeOpenShiftClient(server);
-          this.namespaces = getNamespaceOrUseDefault(namespaces,
-                  getOpenShiftClient());
-
-          Runnable task = new SafeTimerTask() {
-              @Override
-              protected void doRun() throws Exception {
-                  logger.info("Waiting for Jenkins to be started");
-                  while (true) {
-                      final Jenkins instance = Jenkins.getActiveInstance();
-                      // We can look at Jenkins Init Level to see if we are
-                      // ready
-                      // to start. If we do not wait, we risk the chance of a
-                      // deadlock.
-                      //
-                      InitMilestone initLevel = instance.getInitLevel();
-                      logger.fine("Jenkins init level: "
-                              + initLevel.toString());
-                      if (initLevel == InitMilestone.COMPLETED) {
-                          break;
-                      }
-                      logger.fine("Jenkins not ready...");
-                      try {
-                          Thread.sleep(500);
-                      } catch (InterruptedException e) {
-                          // ignore
-                      }
-                  }
-
-                  buildConfigWatcher = new BuildConfigWatcher(namespaces);
-                  buildConfigWatcher.start();
-                  buildWatcher = new BuildWatcher(namespaces);
-                  buildWatcher.start();
-                  configMapWatcher = new ConfigMapWatcher(namespaces);
-                  configMapWatcher.start();
-                  imageStreamWatcher = new ImageStreamWatcher(namespaces);
-                  imageStreamWatcher.start();
-              }
-          };
-          // lets give jenkins a while to get started ;)
-          Timer.get().schedule(task, 1, TimeUnit.SECONDS);
-      } catch (KubernetesClientException e) {
-          if (e.getCause() != null) {
-              logger.log(Level.SEVERE,
-                      "Failed to configure OpenShift Jenkins Sync Plugin: "
-                              + e.getCause());
-          } else {
-              logger.log(Level.SEVERE,
-                      "Failed to configure OpenShift Jenkins Sync Plugin: "
-                              + e);
-          }
-      }
-  }
+					buildConfigWatcher = new BuildConfigWatcher(namespaces);
+					buildConfigWatcher.start();
+					buildWatcher = new BuildWatcher(namespaces);
+					buildWatcher.start();
+					configMapWatcher = new ConfigMapWatcher(namespaces);
+					configMapWatcher.start();
+					imageStreamWatcher = new ImageStreamWatcher(namespaces);
+					imageStreamWatcher.start();
+				}
+			};
+			// lets give jenkins a while to get started ;)
+			Timer.get().schedule(task, 1, TimeUnit.SECONDS);
+		} catch (KubernetesClientException e) {
+			if (e.getCause() != null) {
+				logger.log(Level.SEVERE, "Failed to configure OpenShift Jenkins Sync Plugin: " + e.getCause());
+			} else {
+				logger.log(Level.SEVERE, "Failed to configure OpenShift Jenkins Sync Plugin: " + e);
+			}
+		}
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -53,7 +53,7 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 
   private String jobNamePattern;
 
-  private String skipOrganisationPrefix;
+  private String skipOrganizationPrefix;
 
   private String skipBranchSuffix;
 
@@ -68,13 +68,13 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
   private transient ImageStreamWatcher imageStreamWatcher;
 
   @DataBoundConstructor
-  public GlobalPluginConfiguration(boolean enable, String server, String namespace, String credentialsId, String jobNamePattern, String skipOrganisationPrefix, String skipBranchSuffix) {
+  public GlobalPluginConfiguration(boolean enable, String server, String namespace, String credentialsId, String jobNamePattern, String skipOrganizationPrefix, String skipBranchSuffix) {
     this.enabled = enable;
     this.server = server;
     this.namespaces = StringUtils.isBlank(namespace)?null:namespace.split(" ");
     this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
     this.jobNamePattern = jobNamePattern;
-    this.skipOrganisationPrefix = skipOrganisationPrefix;
+    this.skipOrganizationPrefix = skipOrganizationPrefix;
     this.skipBranchSuffix = skipBranchSuffix;
     configChange();
   }
@@ -164,12 +164,12 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
     this.jobNamePattern = jobNamePattern;
   }
 
-  public String getSkipOrganisationPrefix() {
-    return skipOrganisationPrefix;
+  public String getSkipOrganizationPrefix() {
+    return skipOrganizationPrefix;
   }
 
-  public void setSkipOrganisationPrefix(String skipOrganisationPrefix) {
-    this.skipOrganisationPrefix = skipOrganisationPrefix;
+  public void setSkipOrganizationPrefix(String skipOrganizationPrefix) {
+    this.skipOrganizationPrefix = skipOrganizationPrefix;
   }
 
   public String getSkipBranchSuffix() {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -556,7 +556,7 @@ public class JenkinsUtils {
     }
   }
 
-<<<<<<< HEAD
+
   public static String getFullJobName(WorkflowJob job) {
     return job.getRelativeNameFrom(Jenkins.getInstance());
   }
@@ -599,7 +599,7 @@ public class JenkinsUtils {
     }
     return name;
   }
-=======
+
     public static void removePodTemplate(PodTemplate podTemplate) {
         KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
         if(kubeCloud != null){
@@ -697,6 +697,4 @@ public class JenkinsUtils {
         
         return podTemplate;
     }
-    
->>>>>>> 0eaf671eba1b7bd6ce48b4932eea176492a4e6cc
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -564,15 +564,15 @@ public class JenkinsUtils {
       String orgName = paths[0];
       if (StringUtils.isNotBlank(orgName)) {
         if (config != null) {
-          String skipOrganisationPrefix = config.getSkipOrganisationPrefix();
-          if (StringUtils.isEmpty(skipOrganisationPrefix)) {
-            config.setSkipOrganisationPrefix(orgName);
-            skipOrganisationPrefix = config.getSkipOrganisationPrefix();
+          String skipOrganizationPrefix = config.getSkipOrganizationPrefix();
+          if (StringUtils.isEmpty(skipOrganizationPrefix)) {
+            config.setSkipOrganizationPrefix(orgName);
+            skipOrganizationPrefix = config.getSkipOrganizationPrefix();
           }
 
-          // if the default organisation lets strip the organisation name from the prefix
+          // if the default organization lets strip the organization name from the prefix
           int prefixLength = orgName.length() + 1;
-          if (orgName.equals(skipOrganisationPrefix) && name.length() > prefixLength) {
+          if (orgName.equals(skipOrganizationPrefix) && name.length() > prefixLength) {
             name = name.substring(prefixLength);
           }
         }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -94,737 +94,688 @@ import static org.apache.commons.lang.StringUtils.isBlank;
  */
 public class JenkinsUtils {
 
-  private static final Logger LOGGER = Logger.getLogger(JenkinsUtils.class
-    .getName());
-  private static final String PARAM_FROM_ENV_DESCRIPTION = "From OpenShift Build Environment Variable";
+	private static final Logger LOGGER = Logger.getLogger(JenkinsUtils.class.getName());
+	private static final String PARAM_FROM_ENV_DESCRIPTION = "From OpenShift Build Environment Variable";
 
-  public static Job getJob(String job) {
-    TopLevelItem item = Jenkins.getActiveInstance().getItem(job);
-    if (item instanceof Job) {
-      return (Job) item;
-    }
-    return null;
-  }
+	public static Job getJob(String job) {
+		TopLevelItem item = Jenkins.getActiveInstance().getItem(job);
+		if (item instanceof Job) {
+			return (Job) item;
+		}
+		return null;
+	}
 
-  public static String getRootUrl() {
-    // TODO is there a better place to find this?
-    String root = Jenkins.getActiveInstance().getRootUrl();
-    if (root == null || root.length() == 0) {
-      root = "http://localhost:8080/";
-    }
-    return root;
-  }
+	public static String getRootUrl() {
+		// TODO is there a better place to find this?
+		String root = Jenkins.getActiveInstance().getRootUrl();
+		if (root == null || root.length() == 0) {
+			root = "http://localhost:8080/";
+		}
+		return root;
+	}
 
-  public static void addJobParamForBuildEnvs(WorkflowJob job,
-                                             JenkinsPipelineBuildStrategy strat, boolean replaceExisting)
-    throws IOException {
-    List<EnvVar> envs = strat.getEnv();
-    if (envs.size() > 0) {
-      // build list of current env var names for possible deletion of env
-      // vars currently stored
-      // as job params
-      List<String> envKeys = new ArrayList<String>();
-      for (EnvVar env : envs) {
-        envKeys.add(env.getName());
-      }
-      // get existing property defs, including any manually added from the
-      // jenkins console independent of BC
-      ParametersDefinitionProperty params = job
-        .removeProperty(ParametersDefinitionProperty.class);
-      Map<String, ParameterDefinition> paramMap = new HashMap<String, ParameterDefinition>();
-      // store any existing parameters in map for easy key lookup
-      if (params != null) {
-        List<ParameterDefinition> existingParamList = params
-          .getParameterDefinitions();
-        for (ParameterDefinition param : existingParamList) {
-          // if a user supplied param, add
-          if (param.getDescription() == null
-            || !param.getDescription().equals(
-            PARAM_FROM_ENV_DESCRIPTION))
-            paramMap.put(param.getName(), param);
-          else if (envKeys.contains(param.getName())) {
-            // the env var still exists on the openshift side so
-            // keep
-            paramMap.put(param.getName(), param);
-          }
-        }
-      }
-      for (EnvVar env : envs) {
-        if (replaceExisting) {
-          StringParameterDefinition envVar = new StringParameterDefinition(
-            env.getName(), env.getValue(),
-            PARAM_FROM_ENV_DESCRIPTION);
-          paramMap.put(env.getName(), envVar);
-        } else if (!paramMap.containsKey(env.getName())) {
-          // if list from BC did not have this parameter, it was added
-          // via `oc start-build -e` ... in this
-          // case, we have chosen to make the default value an empty
-          // string
-          StringParameterDefinition envVar = new StringParameterDefinition(
-            env.getName(), "", PARAM_FROM_ENV_DESCRIPTION);
-          paramMap.put(env.getName(), envVar);
-        }
-      }
-      List<ParameterDefinition> newParamList = new ArrayList<ParameterDefinition>(
-        paramMap.values());
-      job.addProperty(new ParametersDefinitionProperty(newParamList));
-    }
-  }
+	public static void addJobParamForBuildEnvs(WorkflowJob job, JenkinsPipelineBuildStrategy strat,
+			boolean replaceExisting) throws IOException {
+		List<EnvVar> envs = strat.getEnv();
+		if (envs.size() > 0) {
+			// build list of current env var names for possible deletion of env
+			// vars currently stored
+			// as job params
+			List<String> envKeys = new ArrayList<String>();
+			for (EnvVar env : envs) {
+				envKeys.add(env.getName());
+			}
+			// get existing property defs, including any manually added from the
+			// jenkins console independent of BC
+			ParametersDefinitionProperty params = job.removeProperty(ParametersDefinitionProperty.class);
+			Map<String, ParameterDefinition> paramMap = new HashMap<String, ParameterDefinition>();
+			// store any existing parameters in map for easy key lookup
+			if (params != null) {
+				List<ParameterDefinition> existingParamList = params.getParameterDefinitions();
+				for (ParameterDefinition param : existingParamList) {
+					// if a user supplied param, add
+					if (param.getDescription() == null || !param.getDescription().equals(PARAM_FROM_ENV_DESCRIPTION))
+						paramMap.put(param.getName(), param);
+					else if (envKeys.contains(param.getName())) {
+						// the env var still exists on the openshift side so
+						// keep
+						paramMap.put(param.getName(), param);
+					}
+				}
+			}
+			for (EnvVar env : envs) {
+				if (replaceExisting) {
+					StringParameterDefinition envVar = new StringParameterDefinition(env.getName(), env.getValue(),
+							PARAM_FROM_ENV_DESCRIPTION);
+					paramMap.put(env.getName(), envVar);
+				} else if (!paramMap.containsKey(env.getName())) {
+					// if list from BC did not have this parameter, it was added
+					// via `oc start-build -e` ... in this
+					// case, we have chosen to make the default value an empty
+					// string
+					StringParameterDefinition envVar = new StringParameterDefinition(env.getName(), "",
+							PARAM_FROM_ENV_DESCRIPTION);
+					paramMap.put(env.getName(), envVar);
+				}
+			}
+			List<ParameterDefinition> newParamList = new ArrayList<ParameterDefinition>(paramMap.values());
+			job.addProperty(new ParametersDefinitionProperty(newParamList));
+		}
+	}
 
-  public static List<Action> setJobRunParamsFromEnv(WorkflowJob job,
-                                                    JenkinsPipelineBuildStrategy strat, List<Action> buildActions) {
-    List<EnvVar> envs = strat.getEnv();
-    List<String> envKeys = new ArrayList<String>();
-    List<ParameterValue> envVarList = new ArrayList<ParameterValue>();
-    if (envs.size() > 0) {
-      // build list of env var keys for compare with existing job params
-      for (EnvVar env : envs) {
-        envKeys.add(env.getName());
-        envVarList.add(new StringParameterValue(env.getName(), env
-          .getValue()));
-      }
-    }
+	public static List<Action> setJobRunParamsFromEnv(WorkflowJob job, JenkinsPipelineBuildStrategy strat,
+			List<Action> buildActions) {
+		List<EnvVar> envs = strat.getEnv();
+		List<String> envKeys = new ArrayList<String>();
+		List<ParameterValue> envVarList = new ArrayList<ParameterValue>();
+		if (envs.size() > 0) {
+			// build list of env var keys for compare with existing job params
+			for (EnvVar env : envs) {
+				envKeys.add(env.getName());
+				envVarList.add(new StringParameterValue(env.getName(), env.getValue()));
+			}
+		}
 
-    // add any existing job params that were not env vars, using their
-    // default values
-    ParametersDefinitionProperty params = job
-      .getProperty(ParametersDefinitionProperty.class);
-    if (params != null) {
-      List<ParameterDefinition> existingParamList = params
-        .getParameterDefinitions();
-      for (ParameterDefinition param : existingParamList) {
-        if (!envKeys.contains(param.getName())) {
-          String type = param.getType();
-          switch (type) {
-            case "BooleanParameterDefinition":
-              BooleanParameterDefinition bpd = (BooleanParameterDefinition) param;
-              envVarList.add(bpd.getDefaultParameterValue());
-              break;
-            case "ChoiceParameterDefintion":
-              ChoiceParameterDefinition cpd = (ChoiceParameterDefinition) param;
-              envVarList.add(cpd.getDefaultParameterValue());
-              break;
-            case "CredentialsParameterDefinition":
-              CredentialsParameterDefinition crpd = (CredentialsParameterDefinition) param;
-              envVarList.add(crpd.getDefaultParameterValue());
-              break;
-            case "FileParameterDefinition":
-              FileParameterDefinition fpd = (FileParameterDefinition) param;
-              envVarList.add(fpd.getDefaultParameterValue());
-              break;
-            // don't currently support since sync-plugin does not claim
-            // subversion plugin as a direct dependency
-                    /*
-                     * case "ListSubversionTagsParameterDefinition":
-                     * ListSubversionTagsParameterDefinition lpd =
-                     * (ListSubversionTagsParameterDefinition)param;
-                     * envVarList.add(lpd.getDefaultParameterValue()); break;
-                     */
-            case "PasswordParameterDefinition":
-              PasswordParameterDefinition ppd = (PasswordParameterDefinition) param;
-              envVarList.add(ppd.getDefaultParameterValue());
-              break;
-            case "RunParameterDefinition":
-              RunParameterDefinition rpd = (RunParameterDefinition) param;
-              envVarList.add(rpd.getDefaultParameterValue());
-              break;
-            case "StringParameterDefinition":
-              StringParameterDefinition spd = (StringParameterDefinition) param;
-              envVarList.add(spd.getDefaultParameterValue());
-              break;
-            default:
-              // used to have the following:
-              // envVarList.add(new
-              // StringParameterValue(param.getName(),
-              // (param.getDefaultParameterValue() != null &&
-              // param.getDefaultParameterValue().getValue() != null ?
-              // param.getDefaultParameterValue().getValue().toString()
-              // : "")));
-              // but mvn verify complained
-              ParameterValue pv = param.getDefaultParameterValue();
-              if (pv != null) {
-                Object val = pv.getValue();
-                if (val != null) {
-                  envVarList.add(new StringParameterValue(param
-                    .getName(), val.toString()));
-                }
-              }
-          }
-        }
-      }
-    }
+		// add any existing job params that were not env vars, using their
+		// default values
+		ParametersDefinitionProperty params = job.getProperty(ParametersDefinitionProperty.class);
+		if (params != null) {
+			List<ParameterDefinition> existingParamList = params.getParameterDefinitions();
+			for (ParameterDefinition param : existingParamList) {
+				if (!envKeys.contains(param.getName())) {
+					String type = param.getType();
+					switch (type) {
+					case "BooleanParameterDefinition":
+						BooleanParameterDefinition bpd = (BooleanParameterDefinition) param;
+						envVarList.add(bpd.getDefaultParameterValue());
+						break;
+					case "ChoiceParameterDefintion":
+						ChoiceParameterDefinition cpd = (ChoiceParameterDefinition) param;
+						envVarList.add(cpd.getDefaultParameterValue());
+						break;
+					case "CredentialsParameterDefinition":
+						CredentialsParameterDefinition crpd = (CredentialsParameterDefinition) param;
+						envVarList.add(crpd.getDefaultParameterValue());
+						break;
+					case "FileParameterDefinition":
+						FileParameterDefinition fpd = (FileParameterDefinition) param;
+						envVarList.add(fpd.getDefaultParameterValue());
+						break;
+					// don't currently support since sync-plugin does not claim
+					// subversion plugin as a direct dependency
+					/*
+					 * case "ListSubversionTagsParameterDefinition":
+					 * ListSubversionTagsParameterDefinition lpd =
+					 * (ListSubversionTagsParameterDefinition)param;
+					 * envVarList.add(lpd.getDefaultParameterValue()); break;
+					 */
+					case "PasswordParameterDefinition":
+						PasswordParameterDefinition ppd = (PasswordParameterDefinition) param;
+						envVarList.add(ppd.getDefaultParameterValue());
+						break;
+					case "RunParameterDefinition":
+						RunParameterDefinition rpd = (RunParameterDefinition) param;
+						envVarList.add(rpd.getDefaultParameterValue());
+						break;
+					case "StringParameterDefinition":
+						StringParameterDefinition spd = (StringParameterDefinition) param;
+						envVarList.add(spd.getDefaultParameterValue());
+						break;
+					default:
+						// used to have the following:
+						// envVarList.add(new
+						// StringParameterValue(param.getName(),
+						// (param.getDefaultParameterValue() != null &&
+						// param.getDefaultParameterValue().getValue() != null ?
+						// param.getDefaultParameterValue().getValue().toString()
+						// : "")));
+						// but mvn verify complained
+						ParameterValue pv = param.getDefaultParameterValue();
+						if (pv != null) {
+							Object val = pv.getValue();
+							if (val != null) {
+								envVarList.add(new StringParameterValue(param.getName(), val.toString()));
+							}
+						}
+					}
+				}
+			}
+		}
 
-    if (envVarList.size() > 0)
-      buildActions.add(new ParametersAction(envVarList));
+		if (envVarList.size() > 0)
+			buildActions.add(new ParametersAction(envVarList));
 
-    return buildActions;
-  }
+		return buildActions;
+	}
 
-  public static List<Action> setJobRunParamsFromEnvAndUIParams(
-    WorkflowJob job, JenkinsPipelineBuildStrategy strat,
-    List<Action> buildActions, ParametersAction params) {
-    List<EnvVar> envs = strat.getEnv();
-    List<ParameterValue> envVarList = new ArrayList<ParameterValue>();
-    if (envs.size() > 0) {
-      // build list of env var keys for compare with existing job params
-      for (EnvVar env : envs) {
-        envVarList.add(new StringParameterValue(env.getName(), env
-          .getValue()));
-      }
-    }
+	public static List<Action> setJobRunParamsFromEnvAndUIParams(WorkflowJob job, JenkinsPipelineBuildStrategy strat,
+			List<Action> buildActions, ParametersAction params) {
+		List<EnvVar> envs = strat.getEnv();
+		List<ParameterValue> envVarList = new ArrayList<ParameterValue>();
+		if (envs.size() > 0) {
+			// build list of env var keys for compare with existing job params
+			for (EnvVar env : envs) {
+				envVarList.add(new StringParameterValue(env.getName(), env.getValue()));
+			}
+		}
 
-    if (params != null)
-      envVarList.addAll(params.getParameters());
+		if (params != null)
+			envVarList.addAll(params.getParameters());
 
-    if (envVarList.size() > 0)
-      buildActions.add(new ParametersAction(envVarList));
+		if (envVarList.size() > 0)
+			buildActions.add(new ParametersAction(envVarList));
 
-    return buildActions;
-  }
+		return buildActions;
+	}
 
-  public static boolean triggerJob(WorkflowJob job, Build build)
-    throws IOException {
-    if (isAlreadyTriggered(job, build)) {
-      return false;
-    }
+	public static boolean triggerJob(WorkflowJob job, Build build) throws IOException {
+		if (isAlreadyTriggered(job, build)) {
+			return false;
+		}
 
-    String buildConfigName = build.getStatus().getConfig().getName();
-    if (isBlank(buildConfigName)) {
-      return false;
-    }
+		String buildConfigName = build.getStatus().getConfig().getName();
+		if (isBlank(buildConfigName)) {
+			return false;
+		}
 
-    BuildConfigProjectProperty bcProp = job
-      .getProperty(BuildConfigProjectProperty.class);
-    if (bcProp == null) {
-      return false;
-    }
+		BuildConfigProjectProperty bcProp = job.getProperty(BuildConfigProjectProperty.class);
+		if (bcProp == null) {
+			return false;
+		}
 
-    switch (bcProp.getBuildRunPolicy()) {
-      case SERIAL_LATEST_ONLY:
-        cancelQueuedBuilds(job, bcProp.getUid());
-        if (job.isBuilding()) {
-          return false;
-        }
-        break;
-      case SERIAL:
-        if (job.isInQueue() || job.isBuilding()) {
-          return false;
-        }
-        break;
-      default:
-    }
+		switch (bcProp.getBuildRunPolicy()) {
+		case SERIAL_LATEST_ONLY:
+			cancelQueuedBuilds(job, bcProp.getUid());
+			if (job.isBuilding()) {
+				return false;
+			}
+			break;
+		case SERIAL:
+			if (job.isInQueue() || job.isBuilding()) {
+				return false;
+			}
+			break;
+		default:
+		}
 
-    ObjectMeta meta = build.getMetadata();
-    String namespace = meta.getNamespace();
-    BuildConfig buildConfig = getAuthenticatedOpenShiftClient()
-      .buildConfigs().inNamespace(namespace)
-      .withName(buildConfigName).get();
-    if (buildConfig == null) {
-      return false;
-    }
+		ObjectMeta meta = build.getMetadata();
+		String namespace = meta.getNamespace();
+		BuildConfig buildConfig = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace)
+				.withName(buildConfigName).get();
+		if (buildConfig == null) {
+			return false;
+		}
 
-    // sync on intern of name should guarantee sync on same actual obj
-    synchronized (buildConfig.getMetadata().getUid().intern()) {
-      updateSourceCredentials(buildConfig);
+		// sync on intern of name should guarantee sync on same actual obj
+		synchronized (buildConfig.getMetadata().getUid().intern()) {
+			updateSourceCredentials(buildConfig);
 
-      // We need to ensure that we do not remove
-      // existing Causes from a Run since other
-      // plugins may rely on them.
-      List<Cause> newCauses = new ArrayList<>();
-      newCauses.add(new BuildCause(build, bcProp.getUid()));
-      CauseAction originalCauseAction = BuildToActionMapper
-        .removeCauseAction(build.getMetadata().getName());
-      if (originalCauseAction != null) {
-        if (LOGGER.isLoggable(Level.FINE)) {
-          LOGGER.fine("Adding existing causes...");
-          for (Cause c : originalCauseAction.getCauses()) {
-            LOGGER.fine("orginal cause: " + c.getShortDescription());
-          }
-        }
-        newCauses.addAll(originalCauseAction.getCauses());
-        if (LOGGER.isLoggable(Level.FINE)) {
-          for (Cause c : newCauses) {
-            LOGGER.fine("new cause: " + c.getShortDescription());
-          }
-        }
-      }
+			// We need to ensure that we do not remove
+			// existing Causes from a Run since other
+			// plugins may rely on them.
+			List<Cause> newCauses = new ArrayList<>();
+			newCauses.add(new BuildCause(build, bcProp.getUid()));
+			CauseAction originalCauseAction = BuildToActionMapper.removeCauseAction(build.getMetadata().getName());
+			if (originalCauseAction != null) {
+				if (LOGGER.isLoggable(Level.FINE)) {
+					LOGGER.fine("Adding existing causes...");
+					for (Cause c : originalCauseAction.getCauses()) {
+						LOGGER.fine("orginal cause: " + c.getShortDescription());
+					}
+				}
+				newCauses.addAll(originalCauseAction.getCauses());
+				if (LOGGER.isLoggable(Level.FINE)) {
+					for (Cause c : newCauses) {
+						LOGGER.fine("new cause: " + c.getShortDescription());
+					}
+				}
+			}
 
-      List<Action> buildActions = new ArrayList<>();
-      CauseAction bCauseAction = new CauseAction(newCauses);
-      buildActions.add(bCauseAction);
+			List<Action> buildActions = new ArrayList<>();
+			CauseAction bCauseAction = new CauseAction(newCauses);
+			buildActions.add(bCauseAction);
 
-      GitBuildSource gitBuildSource = build.getSpec().getSource()
-        .getGit();
-      SourceRevision sourceRevision = build.getSpec().getRevision();
+			GitBuildSource gitBuildSource = build.getSpec().getSource().getGit();
+			SourceRevision sourceRevision = build.getSpec().getRevision();
 
-      if (gitBuildSource != null && sourceRevision != null) {
-        GitSourceRevision gitSourceRevision = sourceRevision.getGit();
-        if (gitSourceRevision != null) {
-          try {
-            URIish repoURL = new URIish(gitBuildSource.getUri());
-            buildActions.add(new RevisionParameterAction(
-              gitSourceRevision.getCommit(), repoURL));
-          } catch (URISyntaxException e) {
-            LOGGER.log(SEVERE, "Failed to parse git repo URL"
-              + gitBuildSource.getUri(), e);
-          }
-        }
-      }
+			if (gitBuildSource != null && sourceRevision != null) {
+				GitSourceRevision gitSourceRevision = sourceRevision.getGit();
+				if (gitSourceRevision != null) {
+					try {
+						URIish repoURL = new URIish(gitBuildSource.getUri());
+						buildActions.add(new RevisionParameterAction(gitSourceRevision.getCommit(), repoURL));
+					} catch (URISyntaxException e) {
+						LOGGER.log(SEVERE, "Failed to parse git repo URL" + gitBuildSource.getUri(), e);
+					}
+				}
+			}
 
-      ParametersAction userProvidedParams = BuildToActionMapper
-        .removeParameterAction(build.getMetadata().getName());
-      // grab envs from actual build in case user overrode default values
-      // via `oc start-build -e`
-      JenkinsPipelineBuildStrategy strat = build.getSpec().getStrategy()
-        .getJenkinsPipelineStrategy();
-      // only add new param defs for build envs which are not in build
-      // config envs
-      addJobParamForBuildEnvs(job, strat, false);
-      if (userProvidedParams == null) {
-        LOGGER.fine("setting all job run params since this was either started via oc, or started from the UI with no build parameters");
-        // now add the actual param values stemming from openshift build
-        // env vars for this specific job
-        buildActions = setJobRunParamsFromEnv(job, strat, buildActions);
-      } else {
-        LOGGER.fine("setting job run params and since this is manually started from jenkins applying user provided parameters "
-          + userProvidedParams
-          + " along with any from bc's env vars");
-        buildActions = setJobRunParamsFromEnvAndUIParams(job, strat,
-          buildActions, userProvidedParams);
-      }
+			ParametersAction userProvidedParams = BuildToActionMapper
+					.removeParameterAction(build.getMetadata().getName());
+			// grab envs from actual build in case user overrode default values
+			// via `oc start-build -e`
+			JenkinsPipelineBuildStrategy strat = build.getSpec().getStrategy().getJenkinsPipelineStrategy();
+			// only add new param defs for build envs which are not in build
+			// config envs
+			addJobParamForBuildEnvs(job, strat, false);
+			if (userProvidedParams == null) {
+				LOGGER.fine("setting all job run params since this was either started via oc, or started from the UI "
+						+ "with no build parameters");
+				// now add the actual param values stemming from openshift build
+				// env vars for this specific job
+				buildActions = setJobRunParamsFromEnv(job, strat, buildActions);
+			} else {
+				LOGGER.fine("setting job run params and since this is manually started from jenkins applying user "
+						+ "provided parameters " + userProvidedParams + " along with any from bc's env vars");
+				buildActions = setJobRunParamsFromEnvAndUIParams(job, strat, buildActions, userProvidedParams);
+			}
 
-      if (job.scheduleBuild2(0,
-        buildActions.toArray(new Action[buildActions.size()])) != null) {
-        updateOpenShiftBuildPhase(build, PENDING);
-        // If builds are queued too quickly, Jenkins can add the cause
-        // to the previous queued build so let's add a tiny
-        // sleep.
-        try {
-          Thread.sleep(50l);
-        } catch (InterruptedException e) {
-          // Ignore
-        }
-        return true;
-      }
+			if (job.scheduleBuild2(0, buildActions.toArray(new Action[buildActions.size()])) != null) {
+				updateOpenShiftBuildPhase(build, PENDING);
+				// If builds are queued too quickly, Jenkins can add the cause
+				// to the previous queued build so let's add a tiny
+				// sleep.
+				try {
+					Thread.sleep(50l);
+				} catch (InterruptedException e) {
+					// Ignore
+				}
+				return true;
+			}
 
-      return false;
-    }
-  }
+			return false;
+		}
+	}
 
-  private static boolean isAlreadyTriggered(WorkflowJob job, Build build) {
-    return getRun(job, build) != null;
-  }
+	private static boolean isAlreadyTriggered(WorkflowJob job, Build build) {
+		return getRun(job, build) != null;
+	}
 
-  public synchronized static void cancelBuild(WorkflowJob job, Build build) {
-    cancelBuild(job, build, false);
-  }
+	public synchronized static void cancelBuild(WorkflowJob job, Build build) {
+		cancelBuild(job, build, false);
+	}
 
-  public synchronized static void cancelBuild(WorkflowJob job, Build build,
-                                              boolean deleted) {
-    if (!cancelQueuedBuild(job, build)) {
-      cancelRunningBuild(job, build);
-    }
-    if (deleted)
-      return;
-    try {
-      updateOpenShiftBuildPhase(build, CANCELLED);
-    } catch (Exception e) {
-      throw e;
-    }
-  }
+	public synchronized static void cancelBuild(WorkflowJob job, Build build, boolean deleted) {
+		if (!cancelQueuedBuild(job, build)) {
+			cancelRunningBuild(job, build);
+		}
+		if (deleted)
+			return;
+		try {
+			updateOpenShiftBuildPhase(build, CANCELLED);
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-  private static WorkflowRun getRun(WorkflowJob job, Build build) {
-    if (build != null && build.getMetadata() != null) {
-      return getRun(job, build.getMetadata().getUid());
-    }
-    return null;
-  }
+	private static WorkflowRun getRun(WorkflowJob job, Build build) {
+		if (build != null && build.getMetadata() != null) {
+			return getRun(job, build.getMetadata().getUid());
+		}
+		return null;
+	}
 
-  private static WorkflowRun getRun(WorkflowJob job, String buildUid) {
-    for (WorkflowRun run : job.getBuilds()) {
-      BuildCause cause = run.getCause(BuildCause.class);
-      if (cause != null && cause.getUid().equals(buildUid)) {
-        return run;
-      }
-    }
-    return null;
-  }
+	private static WorkflowRun getRun(WorkflowJob job, String buildUid) {
+		for (WorkflowRun run : job.getBuilds()) {
+			BuildCause cause = run.getCause(BuildCause.class);
+			if (cause != null && cause.getUid().equals(buildUid)) {
+				return run;
+			}
+		}
+		return null;
+	}
 
-  private static boolean cancelRunningBuild(WorkflowJob job, Build build) {
-    String buildUid = build.getMetadata().getUid();
-    WorkflowRun run = getRun(job, buildUid);
-    if (run != null && run.isBuilding()) {
-      terminateRun(run);
-      return true;
-    }
-    return false;
-  }
+	private static boolean cancelRunningBuild(WorkflowJob job, Build build) {
+		String buildUid = build.getMetadata().getUid();
+		WorkflowRun run = getRun(job, buildUid);
+		if (run != null && run.isBuilding()) {
+			terminateRun(run);
+			return true;
+		}
+		return false;
+	}
 
-  private static boolean cancelNotYetStartedBuild(WorkflowJob job, Build build) {
-    String buildUid = build.getMetadata().getUid();
-    WorkflowRun run = getRun(job, buildUid);
-    if (run != null && run.hasntStartedYet()) {
-      terminateRun(run);
-      return true;
-    }
-    return false;
-  }
+	private static boolean cancelNotYetStartedBuild(WorkflowJob job, Build build) {
+		String buildUid = build.getMetadata().getUid();
+		WorkflowRun run = getRun(job, buildUid);
+		if (run != null && run.hasntStartedYet()) {
+			terminateRun(run);
+			return true;
+		}
+		return false;
+	}
 
-  private static void cancelNotYetStartedBuilds(WorkflowJob job, String bcUid) {
-    cancelQueuedBuilds(job, bcUid);
-    for (WorkflowRun run : job.getBuilds()) {
-      if (run != null && run.hasntStartedYet()) {
-        BuildCause cause = run.getCause(BuildCause.class);
-        if (cause != null && cause.getBuildConfigUid().equals(bcUid)) {
-          terminateRun(run);
-        }
-      }
-    }
-  }
+	private static void cancelNotYetStartedBuilds(WorkflowJob job, String bcUid) {
+		cancelQueuedBuilds(job, bcUid);
+		for (WorkflowRun run : job.getBuilds()) {
+			if (run != null && run.hasntStartedYet()) {
+				BuildCause cause = run.getCause(BuildCause.class);
+				if (cause != null && cause.getBuildConfigUid().equals(bcUid)) {
+					terminateRun(run);
+				}
+			}
+		}
+	}
 
-  private static void terminateRun(final WorkflowRun run) {
-    ACL.impersonate(ACL.SYSTEM,
-      new NotReallyRoleSensitiveCallable<Void, RuntimeException>() {
-        @Override
-        public Void call() throws RuntimeException {
-          run.doTerm();
-          Timer.get().schedule(new SafeTimerTask() {
-            @Override
-            public void doRun() {
-              ACL.impersonate(
-                ACL.SYSTEM,
-                new NotReallyRoleSensitiveCallable<Void, RuntimeException>() {
-                  @Override
-                  public Void call()
-                    throws RuntimeException {
-                    run.doKill();
-                    return null;
-                  }
-                });
-            }
-          }, 5, TimeUnit.SECONDS);
-          return null;
-        }
-      });
-  }
+	private static void terminateRun(final WorkflowRun run) {
+		ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, RuntimeException>() {
+			@Override
+			public Void call() throws RuntimeException {
+				run.doTerm();
+				Timer.get().schedule(new SafeTimerTask() {
+					@Override
+					public void doRun() {
+						ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, RuntimeException>() {
+							@Override
+							public Void call() throws RuntimeException {
+								run.doKill();
+								return null;
+							}
+						});
+					}
+				}, 5, TimeUnit.SECONDS);
+				return null;
+			}
+		});
+	}
 
-  @SuppressFBWarnings("SE_BAD_FIELD")
-  public static boolean cancelQueuedBuild(WorkflowJob job, Build build) {
-    String buildUid = build.getMetadata().getUid();
-    final Queue buildQueue = Jenkins.getActiveInstance().getQueue();
-    for (final Queue.Item item : buildQueue.getItems()) {
-      for (Cause cause : item.getCauses()) {
-        if (cause instanceof BuildCause
-          && ((BuildCause) cause).getUid().equals(buildUid)) {
-          return ACL
-            .impersonate(
-              ACL.SYSTEM,
-              new NotReallyRoleSensitiveCallable<Boolean, RuntimeException>() {
-                @Override
-                public Boolean call()
-                  throws RuntimeException {
-                  buildQueue.cancel(item);
-                  return true;
-                }
-              });
-        }
-      }
-    }
-    return cancelNotYetStartedBuild(job, build);
-  }
+	@SuppressFBWarnings("SE_BAD_FIELD")
+	public static boolean cancelQueuedBuild(WorkflowJob job, Build build) {
+		String buildUid = build.getMetadata().getUid();
+		final Queue buildQueue = Jenkins.getActiveInstance().getQueue();
+		for (final Queue.Item item : buildQueue.getItems()) {
+			for (Cause cause : item.getCauses()) {
+				if (cause instanceof BuildCause && ((BuildCause) cause).getUid().equals(buildUid)) {
+					return ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Boolean, RuntimeException>() {
+						@Override
+						public Boolean call() throws RuntimeException {
+							buildQueue.cancel(item);
+							return true;
+						}
+					});
+				}
+			}
+		}
+		return cancelNotYetStartedBuild(job, build);
+	}
 
-  public static void cancelQueuedBuilds(WorkflowJob job, String bcUid) {
-    Queue buildQueue = Jenkins.getActiveInstance().getQueue();
-    for (Queue.Item item : buildQueue.getItems()) {
-      for (Cause cause : item.getCauses()) {
-        if (cause instanceof BuildCause) {
-          BuildCause buildCause = (BuildCause) cause;
-          if (buildCause.getBuildConfigUid().equals(bcUid)) {
-            Build build = new BuildBuilder().withNewMetadata()
-              .withNamespace(buildCause.getNamespace())
-              .withName(buildCause.getName()).and().build();
-            cancelQueuedBuild(job, build);
-          }
-        }
-      }
-    }
-  }
+	public static void cancelQueuedBuilds(WorkflowJob job, String bcUid) {
+		Queue buildQueue = Jenkins.getActiveInstance().getQueue();
+		for (Queue.Item item : buildQueue.getItems()) {
+			for (Cause cause : item.getCauses()) {
+				if (cause instanceof BuildCause) {
+					BuildCause buildCause = (BuildCause) cause;
+					if (buildCause.getBuildConfigUid().equals(bcUid)) {
+						Build build = new BuildBuilder().withNewMetadata().withNamespace(buildCause.getNamespace())
+								.withName(buildCause.getName()).and().build();
+						cancelQueuedBuild(job, build);
+					}
+				}
+			}
+		}
+	}
 
-  public static WorkflowJob getJobFromBuild(Build build) {
-    String buildConfigName = build.getStatus().getConfig().getName();
-    if (StringUtils.isEmpty(buildConfigName)) {
-      return null;
-    }
-    BuildConfig buildConfig = getAuthenticatedOpenShiftClient()
-      .buildConfigs().inNamespace(build.getMetadata().getNamespace())
-      .withName(buildConfigName).get();
-    if (buildConfig == null) {
-      return null;
-    }
-    return getJobFromBuildConfig(buildConfig);
-  }
+	public static WorkflowJob getJobFromBuild(Build build) {
+		String buildConfigName = build.getStatus().getConfig().getName();
+		if (StringUtils.isEmpty(buildConfigName)) {
+			return null;
+		}
+		BuildConfig buildConfig = getAuthenticatedOpenShiftClient().buildConfigs()
+				.inNamespace(build.getMetadata().getNamespace()).withName(buildConfigName).get();
+		if (buildConfig == null) {
+			return null;
+		}
+		return getJobFromBuildConfig(buildConfig);
+	}
 
-  public static void maybeScheduleNext(WorkflowJob job) {
-    BuildConfigProjectProperty bcp = job
-      .getProperty(BuildConfigProjectProperty.class);
-    if (bcp == null) {
-      return;
-    }
+	public static void maybeScheduleNext(WorkflowJob job) {
+		BuildConfigProjectProperty bcp = job.getProperty(BuildConfigProjectProperty.class);
+		if (bcp == null) {
+			return;
+		}
 
-    List<Build> builds = getAuthenticatedOpenShiftClient().builds()
-      .inNamespace(bcp.getNamespace())
-      .withField(OPENSHIFT_BUILD_STATUS_FIELD, BuildPhases.NEW)
-      .withLabel(OPENSHIFT_LABELS_BUILD_CONFIG_NAME, bcp.getName())
-      .list().getItems();
-    handleBuildList(job, builds, bcp);
-  }
+		List<Build> builds = getAuthenticatedOpenShiftClient().builds().inNamespace(bcp.getNamespace())
+				.withField(OPENSHIFT_BUILD_STATUS_FIELD, BuildPhases.NEW)
+				.withLabel(OPENSHIFT_LABELS_BUILD_CONFIG_NAME, bcp.getName()).list().getItems();
+		handleBuildList(job, builds, bcp);
+	}
 
-  public static void handleBuildList(WorkflowJob job, List<Build> builds,
-                                     BuildConfigProjectProperty buildConfigProjectProperty) {
-    if (builds.isEmpty()) {
-      return;
-    }
-    boolean isSerialLatestOnly = SERIAL_LATEST_ONLY
-      .equals(buildConfigProjectProperty.getBuildRunPolicy());
-    if (isSerialLatestOnly) {
-      // Try to cancel any builds that haven't actually started, waiting
-      // for executor perhaps.
-      cancelNotYetStartedBuilds(job, buildConfigProjectProperty.getUid());
-    }
-    sort(builds, new Comparator<Build>() {
-      @Override
-      public int compare(Build b1, Build b2) {
-        // Order so cancellations are first in list so we can stop
-        // processing build list when build run policy is
-        // SerialLatestOnly and job is currently building.
-        Boolean b1Cancelled = b1.getStatus() != null
-          && b1.getStatus().getCancelled() != null ? b1
-          .getStatus().getCancelled() : false;
-        Boolean b2Cancelled = b2.getStatus() != null
-          && b2.getStatus().getCancelled() != null ? b2
-          .getStatus().getCancelled() : false;
-        // Inverse comparison as boolean comparison would put false
-        // before true. Could have inverted both cancellation
-        // states but this removes that step.
-        int cancellationCompare = b2Cancelled.compareTo(b1Cancelled);
-        if (cancellationCompare != 0) {
-          return cancellationCompare;
-        }
+	public static void handleBuildList(WorkflowJob job, List<Build> builds,
+			BuildConfigProjectProperty buildConfigProjectProperty) {
+		if (builds.isEmpty()) {
+			return;
+		}
+		boolean isSerialLatestOnly = SERIAL_LATEST_ONLY.equals(buildConfigProjectProperty.getBuildRunPolicy());
+		if (isSerialLatestOnly) {
+			// Try to cancel any builds that haven't actually started, waiting
+			// for executor perhaps.
+			cancelNotYetStartedBuilds(job, buildConfigProjectProperty.getUid());
+		}
+		sort(builds, new Comparator<Build>() {
+			@Override
+			public int compare(Build b1, Build b2) {
+				// Order so cancellations are first in list so we can stop
+				// processing build list when build run policy is
+				// SerialLatestOnly and job is currently building.
+				Boolean b1Cancelled = b1.getStatus() != null && b1.getStatus().getCancelled() != null
+						? b1.getStatus().getCancelled()
+						: false;
+				Boolean b2Cancelled = b2.getStatus() != null && b2.getStatus().getCancelled() != null
+						? b2.getStatus().getCancelled()
+						: false;
+				// Inverse comparison as boolean comparison would put false
+				// before true. Could have inverted both cancellation
+				// states but this removes that step.
+				int cancellationCompare = b2Cancelled.compareTo(b1Cancelled);
+				if (cancellationCompare != 0) {
+					return cancellationCompare;
+				}
 
-        return Long.compare(
-          Long.parseLong(b1.getMetadata().getAnnotations()
-            .get(OPENSHIFT_ANNOTATIONS_BUILD_NUMBER)),
-          Long.parseLong(b2.getMetadata().getAnnotations()
-            .get(OPENSHIFT_ANNOTATIONS_BUILD_NUMBER)));
-      }
-    });
-    boolean isSerial = SERIAL.equals(buildConfigProjectProperty
-      .getBuildRunPolicy());
-    boolean jobIsBuilding = job.isBuilding();
-    for (int i = 0; i < builds.size(); i++) {
-      Build b = builds.get(i);
-      if (!OpenShiftUtils.isPipelineStrategyBuild(b))
-        continue;
-      // For SerialLatestOnly we should try to cancel all builds before
-      // the latest one requested.
-      if (isSerialLatestOnly) {
-        // If the job is currently building, then let's return on the
-        // first non-cancellation request so we do not try to
-        // queue a new build.
-        if (jobIsBuilding && !isCancelled(b.getStatus())) {
-          return;
-        }
+				return Long.compare(
+						Long.parseLong(b1.getMetadata().getAnnotations().get(OPENSHIFT_ANNOTATIONS_BUILD_NUMBER)),
+						Long.parseLong(b2.getMetadata().getAnnotations().get(OPENSHIFT_ANNOTATIONS_BUILD_NUMBER)));
+			}
+		});
+		boolean isSerial = SERIAL.equals(buildConfigProjectProperty.getBuildRunPolicy());
+		boolean jobIsBuilding = job.isBuilding();
+		for (int i = 0; i < builds.size(); i++) {
+			Build b = builds.get(i);
+			if (!OpenShiftUtils.isPipelineStrategyBuild(b))
+				continue;
+			// For SerialLatestOnly we should try to cancel all builds before
+			// the latest one requested.
+			if (isSerialLatestOnly) {
+				// If the job is currently building, then let's return on the
+				// first non-cancellation request so we do not try to
+				// queue a new build.
+				if (jobIsBuilding && !isCancelled(b.getStatus())) {
+					return;
+				}
 
-        if (i < builds.size() - 1) {
-          cancelQueuedBuild(job, b);
-          updateOpenShiftBuildPhase(b, CANCELLED);
-          continue;
-        }
-      }
-      boolean buildAdded = false;
-      try {
-        buildAdded = addEventToJenkinsJobRun(b);
-      } catch (IOException e) {
-        ObjectMeta meta = b.getMetadata();
-        LOGGER.log(WARNING,
-          "Failed to add new build " + meta.getNamespace() + "/"
-            + meta.getName(), e);
-      }
-      // If it's a serial build then we only need to schedule the first
-      // build request.
-      if (isSerial && buildAdded) {
-        return;
-      }
-    }
-  }
+				if (i < builds.size() - 1) {
+					cancelQueuedBuild(job, b);
+					updateOpenShiftBuildPhase(b, CANCELLED);
+					continue;
+				}
+			}
+			boolean buildAdded = false;
+			try {
+				buildAdded = addEventToJenkinsJobRun(b);
+			} catch (IOException e) {
+				ObjectMeta meta = b.getMetadata();
+				LOGGER.log(WARNING, "Failed to add new build " + meta.getNamespace() + "/" + meta.getName(), e);
+			}
+			// If it's a serial build then we only need to schedule the first
+			// build request.
+			if (isSerial && buildAdded) {
+				return;
+			}
+		}
+	}
 
+	public static String getFullJobName(WorkflowJob job) {
+		return job.getRelativeNameFrom(Jenkins.getInstance());
+	}
 
-  public static String getFullJobName(WorkflowJob job) {
-    return job.getRelativeNameFrom(Jenkins.getInstance());
-  }
+	public static String getBuildConfigName(WorkflowJob job) {
+		String name = getFullJobName(job);
+		GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
+		String[] paths = name.split("/");
+		if (paths.length > 1) {
+			String orgName = paths[0];
+			if (StringUtils.isNotBlank(orgName)) {
+				if (config != null) {
+					String skipOrganizationPrefix = config.getSkipOrganizationPrefix();
+					if (StringUtils.isEmpty(skipOrganizationPrefix)) {
+						config.setSkipOrganizationPrefix(orgName);
+						skipOrganizationPrefix = config.getSkipOrganizationPrefix();
+					}
 
-  public static String getBuildConfigName(WorkflowJob job) {
-    String name = getFullJobName(job);
-    GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
-    String[] paths = name.split("/");
-    if (paths.length > 1) {
-      String orgName = paths[0];
-      if (StringUtils.isNotBlank(orgName)) {
-        if (config != null) {
-          String skipOrganizationPrefix = config.getSkipOrganizationPrefix();
-          if (StringUtils.isEmpty(skipOrganizationPrefix)) {
-            config.setSkipOrganizationPrefix(orgName);
-            skipOrganizationPrefix = config.getSkipOrganizationPrefix();
-          }
+					// if the default organization lets strip the organization name from the prefix
+					int prefixLength = orgName.length() + 1;
+					if (orgName.equals(skipOrganizationPrefix) && name.length() > prefixLength) {
+						name = name.substring(prefixLength);
+					}
+				}
+			}
+		}
 
-          // if the default organization lets strip the organization name from the prefix
-          int prefixLength = orgName.length() + 1;
-          if (orgName.equals(skipOrganizationPrefix) && name.length() > prefixLength) {
-            name = name.substring(prefixLength);
-          }
-        }
-      }
-    }
+		// lets avoid the .master postfixes as we treat master as the default branch
+		// name
+		String masterSuffix = "/master";
+		if (config != null) {
+			String skipBranchSuffix = config.getSkipBranchSuffix();
+			if (StringUtils.isEmpty(skipBranchSuffix)) {
+				config.setSkipBranchSuffix("master");
+				skipBranchSuffix = config.getSkipBranchSuffix();
+			}
+			masterSuffix = "/" + skipBranchSuffix;
+		}
+		if (name.endsWith(masterSuffix) && name.length() > masterSuffix.length()) {
+			name = name.substring(0, name.length() - masterSuffix.length());
+		}
+		return name;
+	}
 
-    // lets avoid the .master postfixes as we treat master as the default branch name
-    String masterSuffix = "/master";
-    if (config != null) {
-      String skipBranchSuffix = config.getSkipBranchSuffix();
-      if (StringUtils.isEmpty(skipBranchSuffix)) {
-        config.setSkipBranchSuffix("master");
-        skipBranchSuffix = config.getSkipBranchSuffix();
-      }
-      masterSuffix = "/" + skipBranchSuffix;
-    }
-    if (name.endsWith(masterSuffix) && name.length() > masterSuffix.length()) {
-      name = name.substring(0, name.length() - masterSuffix.length());
-    }
-    return name;
-  }
+	public static void removePodTemplate(PodTemplate podTemplate) {
+		KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
+		if (kubeCloud != null) {
+			LOGGER.info("Removing PodTemplate: " + podTemplate.getName());
+			// NOTE - PodTemplate does not currently override hashCode, equals,
+			// so
+			// the KubernetsCloud.removeTemplate currently is broken;
+			// kubeCloud.removeTemplate(podTemplate);
+			List<PodTemplate> list = kubeCloud.getTemplates();
+			Iterator<PodTemplate> iter = list.iterator();
+			while (iter.hasNext()) {
+				PodTemplate pt = iter.next();
+				if (pt.getName().equals(podTemplate.getName())) {
+					iter.remove();
+				}
+			}
+			// now set new list back into cloud
+			kubeCloud.setTemplates(list);
+			try {
+				// pedantic mvn:findbugs
+				Jenkins jenkins = Jenkins.getInstance();
+				if (jenkins != null)
+					jenkins.save();
+			} catch (IOException e) {
+				LOGGER.log(Level.SEVERE, "removePodTemplate", e);
+			}
 
-  public static void removePodTemplate(PodTemplate podTemplate) {
-    KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
-    if (kubeCloud != null) {
-      LOGGER.info("Removing PodTemplate: " + podTemplate.getName());
-      // NOTE - PodTemplate does not currently override hashCode, equals,
-      // so
-      // the KubernetsCloud.removeTemplate currently is broken;
-      // kubeCloud.removeTemplate(podTemplate);
-      List<PodTemplate> list = kubeCloud.getTemplates();
-      Iterator<PodTemplate> iter = list.iterator();
-      while (iter.hasNext()) {
-        PodTemplate pt = iter.next();
-        if (pt.getName().equals(podTemplate.getName())) {
-          iter.remove();
-        }
-      }
-      // now set new list back into cloud
-      kubeCloud.setTemplates(list);
-      try {
-        // pedantic mvn:findbugs
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins != null)
-          jenkins.save();
-      } catch (IOException e) {
-        LOGGER.log(Level.SEVERE, "removePodTemplate", e);
-      }
+			if (LOGGER.isLoggable(Level.FINE)) {
+				LOGGER.fine("PodTemplates now:");
+				for (PodTemplate pt : kubeCloud.getTemplates()) {
+					LOGGER.fine(pt.getName());
+				}
+			}
+		}
+	}
 
-      if (LOGGER.isLoggable(Level.FINE)) {
-        LOGGER.fine("PodTemplates now:");
-        for (PodTemplate pt : kubeCloud.getTemplates()) {
-          LOGGER.fine(pt.getName());
-        }
-      }
-    }
-  }
+	public static List<PodTemplate> getPodTemplates() {
+		KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
+		if (kubeCloud != null) {
+			// create copy of list for more flexiblity in loops
+			ArrayList<PodTemplate> list = new ArrayList<PodTemplate>();
+			list.addAll(kubeCloud.getTemplates());
+			return list;
+		} else {
+			return null;
+		}
+	}
 
-  public static List<PodTemplate> getPodTemplates() {
-    KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
-    if (kubeCloud != null) {
-      // create copy of list for more flexiblity in loops
-      ArrayList<PodTemplate> list = new ArrayList<PodTemplate>();
-      list.addAll(kubeCloud.getTemplates());
-      return list;
-    } else {
-      return null;
-    }
-  }
+	public static boolean hasPodTemplate(String name) {
+		if (name == null)
+			return false;
+		KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
+		if (kubeCloud != null) {
+			List<PodTemplate> list = kubeCloud.getTemplates();
+			for (PodTemplate pod : list) {
+				if (name.equals(pod.getName()))
+					return true;
+			}
+		}
+		return false;
+	}
 
-  public static boolean hasPodTemplate(String name) {
-    if (name == null)
-      return false;
-    KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
-    if (kubeCloud != null) {
-      List<PodTemplate> list = kubeCloud.getTemplates();
-      for (PodTemplate pod : list) {
-        if (name.equals(pod.getName()))
-          return true;
-      }
-    }
-    return false;
-  }
+	public static void addPodTemplate(PodTemplate podTemplate) {
+		// clear out existing template with same name; k8s plugin maintains
+		// list, not map
+		removePodTemplate(podTemplate);
 
-  public static void addPodTemplate(PodTemplate podTemplate) {
-    // clear out existing template with same name; k8s plugin maintains
-    // list, not map
-    removePodTemplate(podTemplate);
+		KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
+		if (kubeCloud != null) {
+			LOGGER.info("Adding PodTemplate: " + podTemplate.getName());
+			kubeCloud.addTemplate(podTemplate);
+			try {
+				// pedantic mvn:findbugs
+				Jenkins jenkins = Jenkins.getInstance();
+				if (jenkins != null)
+					jenkins.save();
+			} catch (IOException e) {
+				LOGGER.log(Level.SEVERE, "addPodTemplate", e);
+			}
+		}
+	}
 
-    KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
-    if (kubeCloud != null) {
-      LOGGER.info("Adding PodTemplate: " + podTemplate.getName());
-      kubeCloud.addTemplate(podTemplate);
-      try {
-        // pedantic mvn:findbugs
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins != null)
-          jenkins.save();
-      } catch (IOException e) {
-        LOGGER.log(Level.SEVERE, "addPodTemplate", e);
-      }
-    }
-  }
+	public static KubernetesCloud getKubernetesCloud() {
+		// pedantic mvn:findbugs
+		Jenkins jenkins = Jenkins.getInstance();
+		if (jenkins == null)
+			return null;
+		Cloud openShiftCloud = jenkins.getCloud("openshift");
+		if (openShiftCloud instanceof KubernetesCloud) {
+			return (KubernetesCloud) openShiftCloud;
+		}
 
-  public static KubernetesCloud getKubernetesCloud() {
-    // pedantic mvn:findbugs
-    Jenkins jenkins = Jenkins.getInstance();
-    if (jenkins == null)
-      return null;
-    Cloud openShiftCloud = jenkins.getCloud("openshift");
-    if (openShiftCloud instanceof KubernetesCloud) {
-      return (KubernetesCloud) openShiftCloud;
-    }
+		return null;
+	}
 
-    return null;
-  }
+	public static PodTemplate podTemplateInit(String name, String image, String label) {
+		PodTemplate podTemplate = new PodTemplate(image, new ArrayList<PodVolumes.PodVolume>());
+		// with the above ctor guarnateed to have 1 container
+		// also still force our image as the special case "jnlp" container for
+		// the KubernetesSlave;
+		// attempts to use the "jenkinsci/jnlp-slave:alpine" image for a
+		// separate jnlp container
+		// have proved unsuccessful (could not access gihub.com for example)
+		podTemplate.getContainers().get(0).setName("jnlp");
+		// podTemplate.setInstanceCap(Integer.MAX_VALUE);
+		podTemplate.setName(name);
+		podTemplate.setLabel(label);
+		podTemplate.setAlwaysPullImage(false);
+		podTemplate.setCommand("");
+		podTemplate.setArgs("${computer.jnlpmac} ${computer.name}");
+		podTemplate.setRemoteFs("/tmp");
+		String podName = System.getenv().get("HOSTNAME");
+		if (podName != null) {
+			Pod pod = getAuthenticatedOpenShiftClient().pods().withName(podName).get();
+			if (pod != null) {
+				podTemplate.setServiceAccount(pod.getSpec().getServiceAccountName());
+			}
+		}
 
-  public static PodTemplate podTemplateInit(String name, String image,
-                                            String label) {
-    PodTemplate podTemplate = new PodTemplate(image,
-      new ArrayList<PodVolumes.PodVolume>());
-    // with the above ctor guarnateed to have 1 container
-    // also still force our image as the special case "jnlp" container for
-    // the KubernetesSlave;
-    // attempts to use the "jenkinsci/jnlp-slave:alpine" image for a
-    // separate jnlp container
-    // have proved unsuccessful (could not access gihub.com for example)
-    podTemplate.getContainers().get(0).setName("jnlp");
-    // podTemplate.setInstanceCap(Integer.MAX_VALUE);
-    podTemplate.setName(name);
-    podTemplate.setLabel(label);
-    podTemplate.setAlwaysPullImage(false);
-    podTemplate.setCommand("");
-    podTemplate.setArgs("${computer.jnlpmac} ${computer.name}");
-    podTemplate.setRemoteFs("/tmp");
-    String podName = System.getenv().get("HOSTNAME");
-    if (podName != null) {
-      Pod pod = getAuthenticatedOpenShiftClient().pods()
-        .withName(podName).get();
-      if (pod != null) {
-        podTemplate.setServiceAccount(pod.getSpec()
-          .getServiceAccountName());
-      }
-    }
-
-    return podTemplate;
-  }
+		return podTemplate;
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -511,4 +511,47 @@ public class JenkinsUtils {
       }
     }
   }
+
+  public static String getFullJobName(WorkflowJob job) {
+    return job.getRelativeNameFrom(Jenkins.getInstance());
+  }
+
+  public static String getBuildConfigName(WorkflowJob job) {
+    String name = getFullJobName(job);
+    GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
+    String[] paths = name.split("/");
+    if (paths.length > 1) {
+      String orgName = paths[0];
+      if (StringUtils.isNotBlank(orgName)) {
+        if (config != null) {
+          String skipOrganisationPrefix = config.getSkipOrganisationPrefix();
+          if (StringUtils.isEmpty(skipOrganisationPrefix)) {
+            config.setSkipOrganisationPrefix(orgName);
+            skipOrganisationPrefix = config.getSkipOrganisationPrefix();
+          }
+
+          // if the default organisation lets strip the organisation name from the prefix
+          int prefixLength = orgName.length() + 1;
+          if (orgName.equals(skipOrganisationPrefix) && name.length() > prefixLength) {
+            name = name.substring(prefixLength);
+          }
+        }
+      }
+    }
+
+      // lets avoid the .master postfixes as we treat master as the default branch name
+    String masterSuffix = "/master";
+    if (config != null) {
+      String skipBranchSuffix = config.getSkipBranchSuffix();
+      if (StringUtils.isEmpty(skipBranchSuffix)) {
+        config.setSkipBranchSuffix("master");
+        skipBranchSuffix = config.getSkipBranchSuffix();
+      }
+      masterSuffix = "/" + skipBranchSuffix;
+    }
+    if (name.endsWith(masterSuffix) && name.length() > masterSuffix.length()) {
+      name = name.substring(0, name.length() - masterSuffix.length());
+    }
+    return name;
+  }
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
-
 import com.cloudbees.hudson.plugins.folder.Folder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -79,547 +78,530 @@ import static java.util.logging.Level.FINE;
  */
 public class OpenShiftUtils {
 
-    private final static Logger logger = Logger.getLogger(OpenShiftUtils.class
-            .getName());
+	private final static Logger logger = Logger.getLogger(OpenShiftUtils.class.getName());
 
-    private static OpenShiftClient openShiftClient;
+	private static OpenShiftClient openShiftClient;
 
-    private static final DateTimeFormatter dateFormatter = ISODateTimeFormat
-            .dateTimeNoMillis();
+	private static final DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTimeNoMillis();
 
-    /**
-     * Initializes an {@link OpenShiftClient}
-     *
-     * @param serverUrl
-     *            the optional URL of where the OpenShift cluster API server is
-     *            running
-     */
-    public synchronized static void initializeOpenShiftClient(String serverUrl) {
-        OpenShiftConfigBuilder configBuilder = new OpenShiftConfigBuilder();
-        if (serverUrl != null && !serverUrl.isEmpty()) {
-            configBuilder.withMasterUrl(serverUrl);
-        }
-        Config config = configBuilder.build();
-        config.setUserAgent("openshift-sync-plugin-"
-                + Jenkins.getInstance().getPluginManager()
-                        .getPlugin("openshift-sync").getVersion() + "/fabric8-"
-                + Version.clientVersion());
-        openShiftClient = new DefaultOpenShiftClient(config);
-    }
+	/**
+	 * Initializes an {@link OpenShiftClient}
+	 *
+	 * @param serverUrl
+	 *            the optional URL of where the OpenShift cluster API server is
+	 *            running
+	 */
+	public synchronized static void initializeOpenShiftClient(String serverUrl) {
+		OpenShiftConfigBuilder configBuilder = new OpenShiftConfigBuilder();
+		if (serverUrl != null && !serverUrl.isEmpty()) {
+			configBuilder.withMasterUrl(serverUrl);
+		}
+		Config config = configBuilder.build();
+		config.setUserAgent("openshift-sync-plugin-"
+				+ Jenkins.getInstance().getPluginManager().getPlugin("openshift-sync").getVersion() + "/fabric8-"
+				+ Version.clientVersion());
+		openShiftClient = new DefaultOpenShiftClient(config);
+	}
 
-    public synchronized static OpenShiftClient getOpenShiftClient() {
-        return openShiftClient;
-    }
+	public synchronized static OpenShiftClient getOpenShiftClient() {
+		return openShiftClient;
+	}
 
-    // Get the current OpenShiftClient and configure to use the current Oauth
-    // token.
-    public synchronized static OpenShiftClient getAuthenticatedOpenShiftClient() {
-        if (openShiftClient != null) {
-            String token = CredentialsUtils.getCurrentToken();
-            if (token.length() > 0) {
-                openShiftClient.getConfiguration().setOauthToken(token);
-            }
-        }
+	// Get the current OpenShiftClient and configure to use the current Oauth
+	// token.
+	public synchronized static OpenShiftClient getAuthenticatedOpenShiftClient() {
+		if (openShiftClient != null) {
+			String token = CredentialsUtils.getCurrentToken();
+			if (token.length() > 0) {
+				openShiftClient.getConfiguration().setOauthToken(token);
+			}
+		}
 
-        return openShiftClient;
-    }
+		return openShiftClient;
+	}
 
-    public synchronized static void shutdownOpenShiftClient() {
-        if (openShiftClient != null) {
-            openShiftClient.close();
-            openShiftClient = null;
-        }
-    }
+	public synchronized static void shutdownOpenShiftClient() {
+		if (openShiftClient != null) {
+			openShiftClient.close();
+			openShiftClient = null;
+		}
+	}
 
-    /**
-     * Checks if a {@link BuildConfig} relates to a Jenkins build
-     *
-     * @param bc
-     *            the BuildConfig
-     * @return true if this is an OpenShift BuildConfig which should be mirrored
-     *         to a Jenkins Job
-     */
-    public static boolean isPipelineStrategyBuildConfig(BuildConfig bc) {
-        if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY
-                .equalsIgnoreCase(bc.getSpec().getStrategy().getType())
-                && bc.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
-            return true;
-        }
+	/**
+	 * Checks if a {@link BuildConfig} relates to a Jenkins build
+	 *
+	 * @param bc
+	 *            the BuildConfig
+	 * @return true if this is an OpenShift BuildConfig which should be mirrored to
+	 *         a Jenkins Job
+	 */
+	public static boolean isPipelineStrategyBuildConfig(BuildConfig bc) {
+		if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY
+				.equalsIgnoreCase(bc.getSpec().getStrategy().getType())
+				&& bc.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
+			return true;
+		}
 
-        ObjectMeta metadata = bc.getMetadata();
-        if (metadata != null) {
-            Map<String, String> annotations = metadata.getAnnotations();
-            if (annotations != null) {
-                if (annotations.get("fabric8.link.jenkins.job/label") != null) {
-                    return true;
-                }
-            }
-        }
+		ObjectMeta metadata = bc.getMetadata();
+		if (metadata != null) {
+			Map<String, String> annotations = metadata.getAnnotations();
+			if (annotations != null) {
+				if (annotations.get("fabric8.link.jenkins.job/label") != null) {
+					return true;
+				}
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    public static boolean isPipelineStrategyBuild(Build b) {
-        if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY
-                .equalsIgnoreCase(b.getSpec().getStrategy().getType())
-                && b.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
-            return true;
-        }
-        return false;
-    }
+	public static boolean isPipelineStrategyBuild(Build b) {
+		if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY.equalsIgnoreCase(b.getSpec().getStrategy().getType())
+				&& b.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
+			return true;
+		}
+		return false;
+	}
 
-  /**
-   * Finds the Jenkins job name for the given {@link BuildConfig}.
-   *
-   * @param bc
-   *            the BuildConfig
-   * @return the jenkins job name for the given BuildConfig
-   */
-  public static String jenkinsJobName(BuildConfig bc) {
-    String namespace = bc.getMetadata().getNamespace();
-    String name = bc.getMetadata().getName();
-    return jenkinsJobName(namespace, name);
+	/**
+	 * Finds the Jenkins job name for the given {@link BuildConfig}.
+	 *
+	 * @param bc
+	 *            the BuildConfig
+	 * @return the jenkins job name for the given BuildConfig
+	 */
+	public static String jenkinsJobName(BuildConfig bc) {
+		String namespace = bc.getMetadata().getNamespace();
+		String name = bc.getMetadata().getName();
+		return jenkinsJobName(namespace, name);
 
-  }
+	}
 
-  /**
-   * Creates the Jenkins Job name for the given buildConfigName
-   *
-   * @param namespace
-   *            the namespace of the build
-   * @param buildConfigName
-   *            the name of the {@link BuildConfig} in in the namespace
-   * @return the jenkins job name for the given namespace and name
-   */
-  public static String jenkinsJobName(String namespace, String buildConfigName) {
-    return namespace + "-" + buildConfigName;
-  }
+	/**
+	 * Creates the Jenkins Job name for the given buildConfigName
+	 *
+	 * @param namespace
+	 *            the namespace of the build
+	 * @param buildConfigName
+	 *            the name of the {@link BuildConfig} in in the namespace
+	 * @return the jenkins job name for the given namespace and name
+	 */
+	public static String jenkinsJobName(String namespace, String buildConfigName) {
+		return namespace + "-" + buildConfigName;
+	}
 
-  /**
-   * Finds the full jenkins job path including folders for the given {@link BuildConfig}.
-   *
-   * @param bc the BuildConfig
-   * @return the jenkins job name for the given BuildConfig
-   */
-  public static String jenkinsJobFullName(BuildConfig bc) {
-    String jobName = getAnnotation(bc, Annotations.JENKINS_JOB_PATH);
-    if (StringUtils.isNotBlank(jobName)) {
-      return jobName;
-    }
-    return getNamespace(bc) + "/" + getName(bc);
-  }
+	/**
+	 * Finds the full jenkins job path including folders for the given
+	 * {@link BuildConfig}.
+	 *
+	 * @param bc
+	 *            the BuildConfig
+	 * @return the jenkins job name for the given BuildConfig
+	 */
+	public static String jenkinsJobFullName(BuildConfig bc) {
+		String jobName = getAnnotation(bc, Annotations.JENKINS_JOB_PATH);
+		if (StringUtils.isNotBlank(jobName)) {
+			return jobName;
+		}
+		return getNamespace(bc) + "/" + getName(bc);
+	}
 
-  /**
-   * Returns the parent for the given item full name or default to the active jenkins if it does not exist
-   */
-  public static ItemGroup getFullNameParent(Jenkins activeJenkins, String fullName, String namespace) {
-    int idx = fullName.lastIndexOf('/');
-    if (idx > 0) {
-      String parentFullName = fullName.substring(0, idx);
-      Item parent = activeJenkins.getItemByFullName(parentFullName);
-      if (parent instanceof ItemGroup) {
-        return (ItemGroup) parent;
-      } else if (parentFullName.equals(namespace)) {
+	/**
+	 * Returns the parent for the given item full name or default to the active
+	 * jenkins if it does not exist
+	 */
+	public static ItemGroup getFullNameParent(Jenkins activeJenkins, String fullName, String namespace) {
+		int idx = fullName.lastIndexOf('/');
+		if (idx > 0) {
+			String parentFullName = fullName.substring(0, idx);
+			Item parent = activeJenkins.getItemByFullName(parentFullName);
+			if (parent instanceof ItemGroup) {
+				return (ItemGroup) parent;
+			} else if (parentFullName.equals(namespace)) {
 
-        // lets lazily create a new folder for this namespace parent
-        Folder folder = new Folder(activeJenkins, namespace);
-        try {
-          folder.setDescription("Folder for the OpenShift project: " + namespace);
-        } catch (IOException e) {
-          // ignore
-        }
-        BulkChange bk = new BulkChange(folder);
-        InputStream jobStream = new StringInputStream(new XStream2().toXML(folder));
-        try {
-          activeJenkins.createProjectFromXML(
-            namespace,
-            jobStream
-          ).save();
-        } catch (IOException e) {
-          logger.warning("Failed to create the Folder: " + namespace);
-        }
-        try {
-          bk.commit();
-        } catch (IOException e) {
-          logger.warning("Failed to commit toe BulkChange for the Folder: " + namespace);
-        }
-        // lets look it up again to be sure
-        parent = activeJenkins.getItemByFullName(namespace);
-        if (parent instanceof ItemGroup) {
-          return (ItemGroup) parent;
-        }
-      }
-    }
-    return activeJenkins;
-  }
+				// lets lazily create a new folder for this namespace parent
+				Folder folder = new Folder(activeJenkins, namespace);
+				try {
+					folder.setDescription("Folder for the OpenShift project: " + namespace);
+				} catch (IOException e) {
+					// ignore
+				}
+				BulkChange bk = new BulkChange(folder);
+				InputStream jobStream = new StringInputStream(new XStream2().toXML(folder));
+				try {
+					activeJenkins.createProjectFromXML(namespace, jobStream).save();
+				} catch (IOException e) {
+					logger.warning("Failed to create the Folder: " + namespace);
+				}
+				try {
+					bk.commit();
+				} catch (IOException e) {
+					logger.warning("Failed to commit toe BulkChange for the Folder: " + namespace);
+				}
+				// lets look it up again to be sure
+				parent = activeJenkins.getItemByFullName(namespace);
+				if (parent instanceof ItemGroup) {
+					return (ItemGroup) parent;
+				}
+			}
+		}
+		return activeJenkins;
+	}
 
-  /**
-   * Finds the Jenkins job display name for the given {@link BuildConfig}.
-   *
-   * @param bc the BuildConfig
-   * @return the jenkins job display name for the given BuildConfig
-   */
-  public static String jenkinsJobDisplayName(BuildConfig bc) {
-    String namespace = bc.getMetadata().getNamespace();
-    String name = bc.getMetadata().getName();
-    return jenkinsJobDisplayName(namespace, name);
-  }
+	/**
+	 * Finds the Jenkins job display name for the given {@link BuildConfig}.
+	 *
+	 * @param bc
+	 *            the BuildConfig
+	 * @return the jenkins job display name for the given BuildConfig
+	 */
+	public static String jenkinsJobDisplayName(BuildConfig bc) {
+		String namespace = bc.getMetadata().getNamespace();
+		String name = bc.getMetadata().getName();
+		return jenkinsJobDisplayName(namespace, name);
+	}
 
-  /**
-   * Creates the Jenkins Job display name for the given buildConfigName
-   *
-   * @param namespace the namespace of the build
-   * @param buildConfigName the name of the {@link BuildConfig} in in the namespace
-   * @return the jenkins job display name for the given namespace and name
-   */
-  public static String jenkinsJobDisplayName(String namespace, String buildConfigName) {
-    return namespace + "/" + buildConfigName;
-  }
+	/**
+	 * Creates the Jenkins Job display name for the given buildConfigName
+	 *
+	 * @param namespace
+	 *            the namespace of the build
+	 * @param buildConfigName
+	 *            the name of the {@link BuildConfig} in in the namespace
+	 * @return the jenkins job display name for the given namespace and name
+	 */
+	public static String jenkinsJobDisplayName(String namespace, String buildConfigName) {
+		return namespace + "/" + buildConfigName;
+	}
 
-  /**
-   * Gets the current namespace running Jenkins inside or returns a reasonable default
-   *
-   * @param configuredNamespaces the optional configured namespace(s)
-   * @param client the OpenShift client
-   * @return the default namespace using either the configuration value, the default namespace on the client or "default"
-   */
-  public static String[] getNamespaceOrUseDefault(String[] configuredNamespaces, OpenShiftClient client) {
-    String[] namespaces = configuredNamespaces;
+	/**
+	 * Gets the current namespace running Jenkins inside or returns a reasonable
+	 * default
+	 *
+	 * @param configuredNamespaces
+	 *            the optional configured namespace(s)
+	 * @param client
+	 *            the OpenShift client
+	 * @return the default namespace using either the configuration value, the
+	 *         default namespace on the client or "default"
+	 */
+	public static String[] getNamespaceOrUseDefault(String[] configuredNamespaces, OpenShiftClient client) {
+		String[] namespaces = configuredNamespaces;
 
-    if (namespaces != null) {
-      for (int i = 0; i < namespaces.length; i++) {
-        if (namespaces[i].startsWith("${") && namespaces[i].endsWith("}")) {
-          String envVar = namespaces[i].substring(2, namespaces[i].length() - 1);
-          namespaces[i] = System.getenv(envVar);
-          if (StringUtils.isBlank(namespaces[i])) {
-            logger.warning("No value defined for namespace environment variable `" + envVar + "`");
-          }
-        }
-      }
-    }
-    if (namespaces == null || namespaces.length == 0) {
-      namespaces = new String[]{client.getNamespace()};
-      if (StringUtils.isBlank(namespaces[0])) {
-        namespaces = new String[]{OPENSHIFT_DEFAULT_NAMESPACE};
-      }
-    }
-    return namespaces;
-  }
+		if (namespaces != null) {
+			for (int i = 0; i < namespaces.length; i++) {
+				if (namespaces[i].startsWith("${") && namespaces[i].endsWith("}")) {
+					String envVar = namespaces[i].substring(2, namespaces[i].length() - 1);
+					namespaces[i] = System.getenv(envVar);
+					if (StringUtils.isBlank(namespaces[i])) {
+						logger.warning("No value defined for namespace environment variable `" + envVar + "`");
+					}
+				}
+			}
+		}
+		if (namespaces == null || namespaces.length == 0) {
+			namespaces = new String[] { client.getNamespace() };
+			if (StringUtils.isBlank(namespaces[0])) {
+				namespaces = new String[] { OPENSHIFT_DEFAULT_NAMESPACE };
+			}
+		}
+		return namespaces;
+	}
 
-    /**
-     * Returns the public URL of the given service
-     *
-     * @param openShiftClient
-     *            the OpenShiftClient to use
-     * @param defaultProtocolText
-     *            the protocol text part of a URL such as <code>http://</code>
-     * @param namespace
-     *            the Kubernetes namespace
-     * @param serviceName
-     *            the service name
-     * @return the external URL of the service
-     */
-    public static String getExternalServiceUrl(OpenShiftClient openShiftClient,
-            String defaultProtocolText, String namespace, String serviceName) {
-        try {
-            RouteList routes = openShiftClient.routes().inNamespace(namespace)
-                    .list();
-            for (Route route : routes.getItems()) {
-                RouteSpec spec = route.getSpec();
-                if (spec != null && spec.getTo() != null
-                        && "Service".equalsIgnoreCase(spec.getTo().getKind())
-                        && serviceName.equalsIgnoreCase(spec.getTo().getName())) {
-                    String host = spec.getHost();
-                    if (host != null && host.length() > 0) {
-                        if (spec.getTls() != null) {
-                            return "https://" + host;
-                        }
-                        return "http://" + host;
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Could not find Route for service "
-                    + namespace + "/" + serviceName + ". " + e, e);
-        }
-        // lets try the portalIP instead
-        try {
-            Service service = openShiftClient.services().inNamespace(namespace)
-                    .withName(serviceName).get();
-            if (service != null) {
-                ServiceSpec spec = service.getSpec();
-                if (spec != null) {
-                    String host = spec.getClusterIP();
-                    if (host != null && host.length() > 0) {
-                        return defaultProtocolText + host;
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Could not find Route for service "
-                    + namespace + "/" + serviceName + ". " + e, e);
-        }
+	/**
+	 * Returns the public URL of the given service
+	 *
+	 * @param openShiftClient
+	 *            the OpenShiftClient to use
+	 * @param defaultProtocolText
+	 *            the protocol text part of a URL such as <code>http://</code>
+	 * @param namespace
+	 *            the Kubernetes namespace
+	 * @param serviceName
+	 *            the service name
+	 * @return the external URL of the service
+	 */
+	public static String getExternalServiceUrl(OpenShiftClient openShiftClient, String defaultProtocolText,
+			String namespace, String serviceName) {
+		try {
+			RouteList routes = openShiftClient.routes().inNamespace(namespace).list();
+			for (Route route : routes.getItems()) {
+				RouteSpec spec = route.getSpec();
+				if (spec != null && spec.getTo() != null && "Service".equalsIgnoreCase(spec.getTo().getKind())
+						&& serviceName.equalsIgnoreCase(spec.getTo().getName())) {
+					String host = spec.getHost();
+					if (host != null && host.length() > 0) {
+						if (spec.getTls() != null) {
+							return "https://" + host;
+						}
+						return "http://" + host;
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.log(Level.WARNING, "Could not find Route for service " + namespace + "/" + serviceName + ". " + e,
+					e);
+		}
+		// lets try the portalIP instead
+		try {
+			Service service = openShiftClient.services().inNamespace(namespace).withName(serviceName).get();
+			if (service != null) {
+				ServiceSpec spec = service.getSpec();
+				if (spec != null) {
+					String host = spec.getClusterIP();
+					if (host != null && host.length() > 0) {
+						return defaultProtocolText + host;
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.log(Level.WARNING, "Could not find Route for service " + namespace + "/" + serviceName + ". " + e,
+					e);
+		}
 
-        // let's try the Jenkins configured root url
-        // this can be needed if someone is not using 'jenkins'
-        // as the service name.
-        String rootUrl = Jenkins.getInstance().getRootUrl();
-        if (StringUtils.isNotEmpty(rootUrl)) {
-            return rootUrl;
-        }
+		// let's try the Jenkins configured root url
+		// this can be needed if someone is not using 'jenkins'
+		// as the service name.
+		String rootUrl = Jenkins.getInstance().getRootUrl();
+		if (StringUtils.isNotEmpty(rootUrl)) {
+			return rootUrl;
+		}
 
-        // lets default to the service DNS name
-        return defaultProtocolText + serviceName;
-    }
+		// lets default to the service DNS name
+		return defaultProtocolText + serviceName;
+	}
 
-    /**
-     * Calculates the external URL to access Jenkins
-     *
-     * @param namespace
-     *            the namespace Jenkins is runing inside
-     * @param openShiftClient
-     *            the OpenShift client
-     * @return the external URL to access Jenkins
-     */
-    public static String getJenkinsURL(OpenShiftClient openShiftClient,
-            String namespace) {
-        return getExternalServiceUrl(openShiftClient, "http://", namespace,
-                "jenkins");
-    }
+	/**
+	 * Calculates the external URL to access Jenkins
+	 *
+	 * @param namespace
+	 *            the namespace Jenkins is runing inside
+	 * @param openShiftClient
+	 *            the OpenShift client
+	 * @return the external URL to access Jenkins
+	 */
+	public static String getJenkinsURL(OpenShiftClient openShiftClient, String namespace) {
+		return getExternalServiceUrl(openShiftClient, "http://", namespace, "jenkins");
+	}
 
-    /**
-     * Lazily creates the GitSource if need be then updates the git URL
-     * 
-     * @param buildConfig
-     *            the BuildConfig to update
-     * @param gitUrl
-     *            the URL to the git repo
-     * @param ref
-     *            the git ref (commit/branch/etc) for the build
-     */
-    public static void updateGitSourceUrl(BuildConfig buildConfig,
-            String gitUrl, String ref) {
-        BuildConfigSpec spec = buildConfig.getSpec();
-        if (spec == null) {
-            spec = new BuildConfigSpec();
-            buildConfig.setSpec(spec);
-        }
-        BuildSource source = spec.getSource();
-        if (source == null) {
-            source = new BuildSource();
-            spec.setSource(source);
-        }
-        source.setType("Git");
-        GitBuildSource gitSource = source.getGit();
-        if (gitSource == null) {
-            gitSource = new GitBuildSource();
-            source.setGit(gitSource);
-        }
-        gitSource.setUri(gitUrl);
-        gitSource.setRef(ref);
-    }
+	/**
+	 * Lazily creates the GitSource if need be then updates the git URL
+	 * 
+	 * @param buildConfig
+	 *            the BuildConfig to update
+	 * @param gitUrl
+	 *            the URL to the git repo
+	 * @param ref
+	 *            the git ref (commit/branch/etc) for the build
+	 */
+	public static void updateGitSourceUrl(BuildConfig buildConfig, String gitUrl, String ref) {
+		BuildConfigSpec spec = buildConfig.getSpec();
+		if (spec == null) {
+			spec = new BuildConfigSpec();
+			buildConfig.setSpec(spec);
+		}
+		BuildSource source = spec.getSource();
+		if (source == null) {
+			source = new BuildSource();
+			spec.setSource(source);
+		}
+		source.setType("Git");
+		GitBuildSource gitSource = source.getGit();
+		if (gitSource == null) {
+			gitSource = new GitBuildSource();
+			source.setGit(gitSource);
+		}
+		gitSource.setUri(gitUrl);
+		gitSource.setRef(ref);
+	}
 
-    public static void updateOpenShiftBuildPhase(Build build, String phase) {
-        logger.log(FINE, "setting build to {0} in namespace {1}/{2}",
-                new Object[] { phase, build.getMetadata().getNamespace(),
-                        build.getMetadata().getName() });
-        getAuthenticatedOpenShiftClient().builds()
-                .inNamespace(build.getMetadata().getNamespace())
-                .withName(build.getMetadata().getName()).edit().editStatus()
-                .withPhase(phase).endStatus().done();
-    }
+	public static void updateOpenShiftBuildPhase(Build build, String phase) {
+		logger.log(FINE, "setting build to {0} in namespace {1}/{2}",
+				new Object[] { phase, build.getMetadata().getNamespace(), build.getMetadata().getName() });
+		getAuthenticatedOpenShiftClient().builds().inNamespace(build.getMetadata().getNamespace())
+				.withName(build.getMetadata().getName()).edit().editStatus().withPhase(phase).endStatus().done();
+	}
 
-    /**
-     * Maps a Jenkins Job name to an ObjectShift BuildConfig name
-     *
-     * @return the namespaced name for the BuildConfig
-     * @param jobName
-     *            the job to associate to a BuildConfig name
-     * @param namespace
-     *            the default namespace that Jenkins is running inside
-     */
-    public static NamespaceName buildConfigNameFromJenkinsJobName(
-            String jobName, String namespace) {
-        // TODO lets detect the namespace separator in the jobName for cases
-        // where a jenkins is used for
-        // BuildConfigs in multiple namespaces?
-        return new NamespaceName(namespace, jobName);
-    }
+	/**
+	 * Maps a Jenkins Job name to an ObjectShift BuildConfig name
+	 *
+	 * @return the namespaced name for the BuildConfig
+	 * @param jobName
+	 *            the job to associate to a BuildConfig name
+	 * @param namespace
+	 *            the default namespace that Jenkins is running inside
+	 */
+	public static NamespaceName buildConfigNameFromJenkinsJobName(String jobName, String namespace) {
+		// TODO lets detect the namespace separator in the jobName for cases
+		// where a jenkins is used for
+		// BuildConfigs in multiple namespaces?
+		return new NamespaceName(namespace, jobName);
+	}
 
-    public static long parseResourceVersion(HasMetadata obj) {
-        return parseResourceVersion(obj.getMetadata().getResourceVersion());
-    }
+	public static long parseResourceVersion(HasMetadata obj) {
+		return parseResourceVersion(obj.getMetadata().getResourceVersion());
+	}
 
-    public static long parseResourceVersion(String resourceVersion) {
-        try {
-            return Long.parseLong(resourceVersion);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
+	public static long parseResourceVersion(String resourceVersion) {
+		try {
+			return Long.parseLong(resourceVersion);
+		} catch (NumberFormatException e) {
+			return 0;
+		}
+	}
 
-    public static String formatTimestamp(long timestamp) {
-        return dateFormatter.print(new DateTime(timestamp));
-    }
+	public static String formatTimestamp(long timestamp) {
+		return dateFormatter.print(new DateTime(timestamp));
+	}
 
-    public static long parseTimestamp(String timestamp) {
-        return dateFormatter.parseMillis(timestamp);
-    }
+	public static long parseTimestamp(String timestamp) {
+		return dateFormatter.parseMillis(timestamp);
+	}
 
-    public static boolean isResourceWithoutStateEqual(HasMetadata oldObj,
-            HasMetadata newObj) {
-        try {
-            byte[] oldDigest = MessageDigest.getInstance("MD5").digest(
-                    dumpWithoutRuntimeStateAsYaml(oldObj).getBytes(
-                            StandardCharsets.UTF_8));
-            byte[] newDigest = MessageDigest.getInstance("MD5").digest(
-                    dumpWithoutRuntimeStateAsYaml(newObj).getBytes(
-                            StandardCharsets.UTF_8));
-            return Arrays.equals(oldDigest, newDigest);
-        } catch (NoSuchAlgorithmException | JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
+	public static boolean isResourceWithoutStateEqual(HasMetadata oldObj, HasMetadata newObj) {
+		try {
+			byte[] oldDigest = MessageDigest.getInstance("MD5")
+					.digest(dumpWithoutRuntimeStateAsYaml(oldObj).getBytes(StandardCharsets.UTF_8));
+			byte[] newDigest = MessageDigest.getInstance("MD5")
+					.digest(dumpWithoutRuntimeStateAsYaml(newObj).getBytes(StandardCharsets.UTF_8));
+			return Arrays.equals(oldDigest, newDigest);
+		} catch (NoSuchAlgorithmException | JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    public static String dumpWithoutRuntimeStateAsYaml(HasMetadata obj)
-            throws JsonProcessingException {
-        ObjectMapper statelessMapper = new ObjectMapper(new YAMLFactory());
-        statelessMapper.addMixInAnnotations(ObjectMeta.class,
-                ObjectMetaMixIn.class);
-        statelessMapper.addMixInAnnotations(ReplicationController.class,
-                StatelessReplicationControllerMixIn.class);
-        return statelessMapper.writeValueAsString(obj);
-    }
+	public static String dumpWithoutRuntimeStateAsYaml(HasMetadata obj) throws JsonProcessingException {
+		ObjectMapper statelessMapper = new ObjectMapper(new YAMLFactory());
+		statelessMapper.addMixInAnnotations(ObjectMeta.class, ObjectMetaMixIn.class);
+		statelessMapper.addMixInAnnotations(ReplicationController.class, StatelessReplicationControllerMixIn.class);
+		return statelessMapper.writeValueAsString(obj);
+	}
 
-    public static boolean isCancellable(BuildStatus buildStatus) {
-        String phase = buildStatus.getPhase();
-        return phase.equals(NEW) || phase.equals(PENDING)
-                || phase.equals(RUNNING);
-    }
+	public static boolean isCancellable(BuildStatus buildStatus) {
+		String phase = buildStatus.getPhase();
+		return phase.equals(NEW) || phase.equals(PENDING) || phase.equals(RUNNING);
+	}
 
-    public static boolean isNew(BuildStatus buildStatus) {
-      return buildStatus.getPhase().equals(NEW);
-    }
+	public static boolean isNew(BuildStatus buildStatus) {
+		return buildStatus.getPhase().equals(NEW);
+	}
 
-    public static boolean isCancelled(BuildStatus status) {
-      return status != null && status.getCancelled() != null
-        && Boolean.TRUE.equals(status.getCancelled());
-    }
+	public static boolean isCancelled(BuildStatus status) {
+		return status != null && status.getCancelled() != null && Boolean.TRUE.equals(status.getCancelled());
+	}
 
-  /**
-   * Lets convert the string to btw a valid kubernetes resource name
-   */
-  static String convertNameToValidResourceName(String text) {
-    String lower = text.toLowerCase();
-    StringBuilder builder = new StringBuilder();
-    boolean started = false;
-    char lastCh = ' ';
-    for (int i = 0, last = lower.length() - 1; i <= last; i++) {
-      char ch = lower.charAt(i);
-      if (!(ch >= 'a' && ch <= 'z') && !(ch >= '0' && ch <= '9')) {
-        if (ch == '/') {
-          ch = '.';
-        } else if (ch != '.' && ch != '-') {
-          ch = '-';
-        }
-        if (!started || lastCh == '-' || lastCh == '.' || i == last) {
-          continue;
-        }
-      }
-      builder.append(ch);
-      started = true;
-      lastCh = ch;
-    }
-    return builder.toString();
-  }
+	/**
+	 * Lets convert the string to btw a valid kubernetes resource name
+	 */
+	static String convertNameToValidResourceName(String text) {
+		String lower = text.toLowerCase();
+		StringBuilder builder = new StringBuilder();
+		boolean started = false;
+		char lastCh = ' ';
+		for (int i = 0, last = lower.length() - 1; i <= last; i++) {
+			char ch = lower.charAt(i);
+			if (!(ch >= 'a' && ch <= 'z') && !(ch >= '0' && ch <= '9')) {
+				if (ch == '/') {
+					ch = '.';
+				} else if (ch != '.' && ch != '-') {
+					ch = '-';
+				}
+				if (!started || lastCh == '-' || lastCh == '.' || i == last) {
+					continue;
+				}
+			}
+			builder.append(ch);
+			started = true;
+			lastCh = ch;
+		}
+		return builder.toString();
+	}
 
-  public static String getAnnotation(HasMetadata resource, String name) {
-    ObjectMeta metadata = resource.getMetadata();
-    if (metadata != null) {
-      Map<String, String> annotations = metadata.getAnnotations();
-      if (annotations != null) {
-        return annotations.get(name);
-      }
-    }
-    return null;
-  }
+	public static String getAnnotation(HasMetadata resource, String name) {
+		ObjectMeta metadata = resource.getMetadata();
+		if (metadata != null) {
+			Map<String, String> annotations = metadata.getAnnotations();
+			if (annotations != null) {
+				return annotations.get(name);
+			}
+		}
+		return null;
+	}
 
+	public static void addAnnotation(HasMetadata resource, String name, String value) {
+		ObjectMeta metadata = resource.getMetadata();
+		if (metadata == null) {
+			metadata = new ObjectMeta();
+			resource.setMetadata(metadata);
+		}
+		Map<String, String> annotations = metadata.getAnnotations();
+		if (annotations == null) {
+			annotations = new HashMap<>();
+			metadata.setAnnotations(annotations);
+		}
+		annotations.put(name, value);
+	}
 
-  public static void addAnnotation(HasMetadata resource, String name, String value) {
-    ObjectMeta metadata = resource.getMetadata();
-    if (metadata == null) {
-      metadata = new ObjectMeta();
-      resource.setMetadata(metadata);
-    }
-    Map<String, String> annotations = metadata.getAnnotations();
-    if (annotations == null) {
-      annotations = new HashMap<>();
-      metadata.setAnnotations(annotations);
-    }
-    annotations.put(name, value);
-  }
+	public static String getNamespace(HasMetadata resource) {
+		ObjectMeta metadata = resource.getMetadata();
+		if (metadata != null) {
+			return metadata.getNamespace();
+		}
+		return null;
+	}
 
-  public static String getNamespace(HasMetadata resource) {
-    ObjectMeta metadata = resource.getMetadata();
-    if (metadata != null) {
-      return metadata.getNamespace();
-    }
-    return null;
-  }
+	public static String getName(HasMetadata resource) {
+		ObjectMeta metadata = resource.getMetadata();
+		if (metadata != null) {
+			return metadata.getName();
+		}
+		return null;
+	}
 
-  public static String getName(HasMetadata resource) {
-    ObjectMeta metadata = resource.getMetadata();
-    if (metadata != null) {
-      return metadata.getName();
-    }
-    return null;
-  }
+	abstract class StatelessReplicationControllerMixIn extends ReplicationController {
+		@JsonIgnore
+		private ReplicationControllerStatus status;
 
-   abstract class StatelessReplicationControllerMixIn extends
-            ReplicationController {
-        @JsonIgnore
-        private ReplicationControllerStatus status;
+		StatelessReplicationControllerMixIn() {
+		}
 
-        StatelessReplicationControllerMixIn() {
-        }
+		@JsonIgnore
+		public abstract ReplicationControllerStatus getStatus();
+	}
 
-        @JsonIgnore
-        public abstract ReplicationControllerStatus getStatus();
-    }
+	abstract class ObjectMetaMixIn extends ObjectMeta {
+		@JsonIgnore
+		private String creationTimestamp;
+		@JsonIgnore
+		private String deletionTimestamp;
+		@JsonIgnore
+		private Long generation;
+		@JsonIgnore
+		private String resourceVersion;
+		@JsonIgnore
+		private String selfLink;
+		@JsonIgnore
+		private String uid;
 
-   abstract class ObjectMetaMixIn extends ObjectMeta {
-        @JsonIgnore
-        private String creationTimestamp;
-        @JsonIgnore
-        private String deletionTimestamp;
-        @JsonIgnore
-        private Long generation;
-        @JsonIgnore
-        private String resourceVersion;
-        @JsonIgnore
-        private String selfLink;
-        @JsonIgnore
-        private String uid;
+		ObjectMetaMixIn() {
+		}
 
-        ObjectMetaMixIn() {
-        }
+		@JsonIgnore
+		public abstract String getCreationTimestamp();
 
-        @JsonIgnore
-        public abstract String getCreationTimestamp();
+		@JsonIgnore
+		public abstract String getDeletionTimestamp();
 
-        @JsonIgnore
-        public abstract String getDeletionTimestamp();
+		@JsonIgnore
+		public abstract Long getGeneration();
 
-        @JsonIgnore
-        public abstract Long getGeneration();
+		@JsonIgnore
+		public abstract String getResourceVersion();
 
-        @JsonIgnore
-        public abstract String getResourceVersion();
+		@JsonIgnore
+		public abstract String getSelfLink();
 
-        @JsonIgnore
-        public abstract String getSelfLink();
-
-        @JsonIgnore
-        public abstract String getUid();
-   }
+		@JsonIgnore
+		public abstract String getUid();
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -204,7 +204,7 @@ public class PipelineJobListener extends ItemListener {
 
   private void upsertBuildConfigForJob(WorkflowJob job, BuildConfigProjectProperty buildConfigProjectProperty) {
     boolean create = false;
-    BuildConfig jobBuildConfig = getOpenShiftClient().buildConfigs().
+    BuildConfig jobBuildConfig = getAuthenticatedOpenShiftClient().buildConfigs().
             inNamespace(buildConfigProjectProperty.getNamespace()).withName(buildConfigProjectProperty.getName()).get();
     if (jobBuildConfig == null) {
       create = true;
@@ -241,7 +241,7 @@ public class PipelineJobListener extends ItemListener {
     
     if (create) {
       try {
-        BuildConfig bc = getOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
+        BuildConfig bc = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
         String uid = bc.getMetadata().getUid();
         buildConfigProjectProperty.setUid(uid);
       } catch (Exception e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -16,15 +16,25 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.google.common.base.Objects;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.listeners.ItemListener;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.BuildConfigSpec;
+import io.fabric8.openshift.api.model.BuildSource;
+import io.fabric8.openshift.api.model.BuildStrategy;
+import io.fabric8.openshift.api.model.GitBuildSource;
+import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,7 +43,6 @@ import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMapper.updateBuil
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
  * Listens to {@link WorkflowJob} objects being updated via the web console or Jenkins REST API and replicating
@@ -46,6 +55,7 @@ public class PipelineJobListener extends ItemListener {
 
   private String server;
   private String[] namespaces;
+  private String jobNamePattern;
 
   public PipelineJobListener() {
     init();
@@ -53,10 +63,20 @@ public class PipelineJobListener extends ItemListener {
 
   @DataBoundConstructor
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public PipelineJobListener(String server, String[] namespaces) {
+  public PipelineJobListener(String server, String[] namespaces, String jobNamePattern) {
     this.server = server;
     this.namespaces = namespaces;
+    this.jobNamePattern = jobNamePattern;
     init();
+  }
+
+  @Override
+  public String toString() {
+    return "PipelineJobListener{" +
+            "server='" + server + '\'' +
+            ", namespace='" + namespaces + '\'' +
+            ", jobNamePattern='" + jobNamePattern + '\'' +
+            '}';
   }
 
   private void init() {
@@ -65,31 +85,34 @@ public class PipelineJobListener extends ItemListener {
 
   @Override
   public void onCreated(Item item) {
+    reconfigure();
     super.onCreated(item);
     upsertItem(item);
   }
 
   @Override
   public void onUpdated(Item item) {
+    reconfigure();
     super.onUpdated(item);
     upsertItem(item);
   }
 
   @Override
   public void onDeleted(Item item) {
+    reconfigure();
     super.onDeleted(item);
     if (item instanceof WorkflowJob) {
       WorkflowJob job = (WorkflowJob) item;
-      if (job.getProperty(BuildConfigProjectProperty.class) != null
-        && isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getNamespace())
-        && isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getName())) {
+      BuildConfigProjectProperty property = buildConfigProjectForJob(job);
+      if (property != null) {
+        logger.info("Deleting BuildConfig " + property.getNamespace() + "/" + property.getName());
 
         NamespaceName buildName = OpenShiftUtils.buildConfigNameFromJenkinsJobName(job.getName(), job.getProperty(BuildConfigProjectProperty.class).getNamespace());
-        logger.info("Deleting BuildConfig " + buildName);
 
         String namespace = buildName.getNamespace();
         String buildConfigName = buildName.getName();
         BuildConfig buildConfig = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace).withName(buildConfigName).get();
+
         if (buildConfig != null) {
           try {
             getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace).withName(buildConfigName).delete();
@@ -109,34 +132,170 @@ public class PipelineJobListener extends ItemListener {
 
   public void upsertItem(Item item) {
     if (item instanceof WorkflowJob) {
-      WorkflowJob job = (WorkflowJob) item;
-      if (job.getProperty(BuildConfigProjectProperty.class) != null
-        && StringUtils.isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getNamespace())
-        && StringUtils.isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getName())) {
-        logger.info("Updated WorkflowJob " + job.getDisplayName() + " replicating changes to OpenShift");
-        upsertBuildConfigForJob(job);
+      upsertWorkflowJob((WorkflowJob) item);
+    } else if (item instanceof ItemGroup) {
+      upsertItemGroup((ItemGroup) item);
+    }
+  }
+
+  private void upsertItemGroup(ItemGroup itemGroup) {
+    Collection items = itemGroup.getItems();
+    if (items != null) {
+      for (Object child : items) {
+        if (child instanceof WorkflowJob) {
+          upsertWorkflowJob((WorkflowJob) child);
+        } else if (child instanceof ItemGroup) {
+          upsertItemGroup((ItemGroup) child);
+        }
       }
     }
   }
 
-  // TODO handle syncing created jobs back to a new OpenShift BuildConfig
-  private void upsertBuildConfigForJob(WorkflowJob job) {
-    BuildConfigProjectProperty buildConfigProjectProperty = job.getProperty(BuildConfigProjectProperty.class);
-    if (buildConfigProjectProperty == null || buildConfigProjectProperty.getNamespace() == null || buildConfigProjectProperty.getName() == null || buildConfigProjectProperty.getUid() == null) {
-      return;
+  private void upsertWorkflowJob(WorkflowJob job) {
+    BuildConfigProjectProperty property = buildConfigProjectForJob(job);
+    if (property != null) {
+      logger.info("Upsert WorkflowJob " + job.getName() + " to BuildConfig: "+ property.getNamespace() + "/" + property.getName() + " in OpenShift");
+      upsertBuildConfigForJob(job, property);
+    }
+  }
+
+  /**
+   * Returns the mapping of the jenkins workflow job to a qualified namespace and BuildConfig name
+   */
+  private BuildConfigProjectProperty buildConfigProjectForJob(WorkflowJob job) {
+
+    BuildConfigProjectProperty property = job.getProperty(BuildConfigProjectProperty.class);
+
+    if (property != null) {
+      if (StringUtils.isNotBlank(property.getNamespace()) && StringUtils.isNotBlank(property.getName())) {
+        logger.info("Found BuildConfigProjectProperty for namespace: " + property.getNamespace() + " name: " + property.getName());
+        return property;
+      }
     }
 
-    BuildConfig jobBuildConfig = buildConfigProjectProperty.getBuildConfig();
+    String patternRegex = this.jobNamePattern;
+    String jobName = JenkinsUtils.getFullJobName(job);
+    if (StringUtils.isNotEmpty(jobName) && StringUtils.isNotEmpty(patternRegex) && jobName.matches(patternRegex)) {
+      String buildConfigName = OpenShiftUtils.convertNameToValidResourceName(JenkinsUtils.getBuildConfigName(job));
+
+      // we will update the uuid when we create the BC
+      String uuid = null;
+
+      // TODO what to do for the resourceVersion?
+      String resourceVersion = null;
+      String buildRunPolicy = "Serial";
+      for (String namespace: namespaces){
+        logger.info("Creating BuildConfigProjectProperty for namespace: " + namespace + " name: " + buildConfigName);
+        if (property != null) {
+          property.setNamespace(namespace);
+          property.setName(buildConfigName);
+          if (!StringUtils.isNotBlank(property.getBuildRunPolicy())) {
+            property.setBuildRunPolicy(buildRunPolicy);
+          }
+          return property;
+        } else {
+          return new BuildConfigProjectProperty(namespace, buildConfigName, uuid, resourceVersion, buildRunPolicy);
+        }
+      }
+
+    }
+    return null;
+  }
+
+  private void upsertBuildConfigForJob(WorkflowJob job, BuildConfigProjectProperty buildConfigProjectProperty) {
+    boolean create = false;
+    BuildConfig jobBuildConfig = getOpenShiftClient().buildConfigs().
+            inNamespace(buildConfigProjectProperty.getNamespace()).withName(buildConfigProjectProperty.getName()).get();
     if (jobBuildConfig == null) {
-      logger.log(Level.WARNING, "Failed to find BuildConfig in namespace: " + buildConfigProjectProperty.getNamespace() + " for name: " + buildConfigProjectProperty.getName());
-      return;
+      create = true;
+      jobBuildConfig = new BuildConfigBuilder().
+              withNewMetadata().withName(buildConfigProjectProperty.getName()).
+              withNamespace(buildConfigProjectProperty.getNamespace()).
+              addToAnnotations(Annotations.GENERATED_BY, "jenkins").
+              endMetadata().
+              withNewSpec().
+              withNewStrategy().withType("JenkinsPipeline").withNewJenkinsPipelineStrategy().endJenkinsPipelineStrategy().endStrategy().
+              endSpec().build();
+    } else {
+      ObjectMeta metadata = jobBuildConfig.getMetadata();
+      String uid = buildConfigProjectProperty.getUid();
+      if (metadata != null && StringUtils.isEmpty(uid)) {
+        buildConfigProjectProperty.setUid(metadata.getUid());
+      } else if (metadata != null && !Objects.equal(uid, metadata.getUid())) {
+        // the UUIDs are different so lets ignore this BC
+        return;
+      }
     }
     updateBuildConfigFromJob(job, jobBuildConfig);
 
-    try {
-      getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).withName(jobBuildConfig.getMetadata().getName()).cascading(false).replace(jobBuildConfig);
-    } catch (Exception e) {
-      logger.log(Level.WARNING, "Failed to update BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
+
+
+    if (!hasEmbeddedPipelineOrValidSource(jobBuildConfig)) {
+      // this pipeline has not yet been populated with the git source or an embedded pipeline so lets not create/update a BC yet
+      return;
+    }
+
+    // lets annotate with the job name
+    if (create) {
+      OpenShiftUtils.addAnnotation(jobBuildConfig, Annotations.JENKINS_JOB_PATH, JenkinsUtils.getFullJobName(job));
+    }
+    
+    if (create) {
+      try {
+        BuildConfig bc = getOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
+        String uid = bc.getMetadata().getUid();
+        buildConfigProjectProperty.setUid(uid);
+      } catch (Exception e) {
+        logger.log(Level.WARNING, "Failed to create BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
+      }
+    } else {
+      try {
+        getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).withName(jobBuildConfig.getMetadata().getName()).cascading(false).replace(jobBuildConfig);
+      } catch (Exception e) {
+        logger.log(Level.WARNING, "Failed to update BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
+      }
     }
   }
+
+  private boolean hasEmbeddedPipelineOrValidSource(BuildConfig buildConfig) {
+    BuildConfigSpec spec = buildConfig.getSpec();
+    if (spec != null) {
+      BuildStrategy strategy = spec.getStrategy();
+      if (strategy != null) {
+        JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+        if (jenkinsPipelineStrategy != null) {
+          if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfile())) {
+            return true;
+          }
+          if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+            BuildSource source = spec.getSource();
+            if (source != null) {
+              GitBuildSource git = source.getGit();
+              if (git != null) {
+                if (StringUtils.isNotBlank(git.getUri())) {
+                  return true;
+                }
+              }
+              // TODO support other SCMs
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * TODO is there a cleaner way to get this class injected with any new configuration from GlobalPluginConfiguration?
+   */
+  private void reconfigure() {
+    GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
+    if (config != null) {
+      this.jobNamePattern = config.getJobNamePattern();
+      this.namespaces = (config.getNamespace()).split(" ");
+      this.server = config.getServer();
+    }
+  }
+
+
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -52,270 +52,267 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
  */
 @Extension
 public class PipelineJobListener extends ItemListener {
-    private static final Logger logger = Logger
-            .getLogger(PipelineJobListener.class.getName());
+	private static final Logger logger = Logger.getLogger(PipelineJobListener.class.getName());
 
-    private String server;
-    private String[] namespaces;
-    private String jobNamePattern;
+	private String server;
+	private String[] namespaces;
+	private String jobNamePattern;
 
-    public PipelineJobListener() {
-      init();
-    }
+	public PipelineJobListener() {
+		init();
+	}
 
-    @DataBoundConstructor
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public PipelineJobListener(String server, String[] namespaces, String jobNamePattern) {
-      this.server = server;
-      this.namespaces = namespaces;
-      this.jobNamePattern = jobNamePattern;
-      init();
-    }
+	@DataBoundConstructor
+	@SuppressFBWarnings("EI_EXPOSE_REP2")
+	public PipelineJobListener(String server, String[] namespaces, String jobNamePattern) {
+		this.server = server;
+		this.namespaces = namespaces;
+		this.jobNamePattern = jobNamePattern;
+		init();
+	}
 
-    @Override
-    public String toString() {
-      return "PipelineJobListener{" +
-              "server='" + server + '\'' +
-              ", namespace='" + namespaces + '\'' +
-              ", jobNamePattern='" + jobNamePattern + '\'' +
-              '}';
-    }
+	@Override
+	public String toString() {
+		return "PipelineJobListener{" + "server='" + server + '\'' + ", namespace='" + namespaces + '\''
+				+ ", jobNamePattern='" + jobNamePattern + '\'' + '}';
+	}
 
-    private void init() {
-      namespaces = OpenShiftUtils.getNamespaceOrUseDefault(namespaces, getOpenShiftClient());
-    }
+	private void init() {
+		namespaces = OpenShiftUtils.getNamespaceOrUseDefault(namespaces, getOpenShiftClient());
+	}
 
-    @Override
-    public void onCreated(Item item) {
-        if (!GlobalPluginConfiguration.get().isEnabled())
-          return;
-        reconfigure();
-        super.onCreated(item);
-        upsertItem(item);
-    }
+	@Override
+	public void onCreated(Item item) {
+		if (!GlobalPluginConfiguration.get().isEnabled())
+			return;
+		reconfigure();
+		super.onCreated(item);
+		upsertItem(item);
+	}
 
-    @Override
-    public void onUpdated(Item item) {
-        if (!GlobalPluginConfiguration.get().isEnabled())
-            return;
-        reconfigure();
-        super.onUpdated(item);
-        upsertItem(item);
-    }
+	@Override
+	public void onUpdated(Item item) {
+		if (!GlobalPluginConfiguration.get().isEnabled())
+			return;
+		reconfigure();
+		super.onUpdated(item);
+		upsertItem(item);
+	}
 
-    @Override
-    public void onDeleted(Item item) {
-        if (!GlobalPluginConfiguration.get().isEnabled())
-            return;
-        reconfigure();
-        super.onDeleted(item);
-        if (item instanceof WorkflowJob) {
-            WorkflowJob job = (WorkflowJob) item;
-            BuildConfigProjectProperty property = buildConfigProjectForJob(job);
-            if (property != null) {
-                logger.info("Deleting BuildConfig " + property.getNamespace() + "/" + property.getName());
+	@Override
+	public void onDeleted(Item item) {
+		if (!GlobalPluginConfiguration.get().isEnabled())
+			return;
+		reconfigure();
+		super.onDeleted(item);
+		if (item instanceof WorkflowJob) {
+			WorkflowJob job = (WorkflowJob) item;
+			BuildConfigProjectProperty property = buildConfigProjectForJob(job);
+			if (property != null) {
+				logger.info("Deleting BuildConfig " + property.getNamespace() + "/" + property.getName());
 
-                NamespaceName buildName = OpenShiftUtils
-                  .buildConfigNameFromJenkinsJobName(job.getName(), job
-                    .getProperty(BuildConfigProjectProperty.class)
-                    .getNamespace());
+				NamespaceName buildName = OpenShiftUtils.buildConfigNameFromJenkinsJobName(job.getName(),
+						job.getProperty(BuildConfigProjectProperty.class).getNamespace());
 
-                String namespace = buildName.getNamespace();
-                String buildConfigName = buildName.getName();
-                BuildConfig buildConfig = getAuthenticatedOpenShiftClient()
-                  .buildConfigs().inNamespace(namespace)
-                  .withName(buildConfigName).get();
-                if (buildConfig != null) {
-                    try {
-                        getAuthenticatedOpenShiftClient().buildConfigs()
-                          .inNamespace(namespace)
-                          .withName(buildConfigName).delete();
-                    } catch (KubernetesClientException e) {
-                        if (HTTP_NOT_FOUND != e.getCode()) {
-                          logger.log(Level.WARNING,
-                            "Failed to delete BuildConfig in namespace: "
-                              + namespace + " for name: "
-                              + buildConfigName, e);
-                        }
-                    } catch (Exception e) {
-                        logger.log(Level.WARNING,
-                          "Failed to delete BuildConfig in namespace: "
-                            + namespace + " for name: "
-                            + buildConfigName, e);
-                    } finally {
-                        removeJobWithBuildConfig(buildConfig);
-                    }
-                }
-            }
-        }
-    }
+				String namespace = buildName.getNamespace();
+				String buildConfigName = buildName.getName();
+				BuildConfig buildConfig = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace)
+						.withName(buildConfigName).get();
+				if (buildConfig != null) {
+					try {
+						getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace)
+								.withName(buildConfigName).delete();
+					} catch (KubernetesClientException e) {
+						if (HTTP_NOT_FOUND != e.getCode()) {
+							logger.log(Level.WARNING, "Failed to delete BuildConfig in namespace: " + namespace
+									+ " for name: " + buildConfigName, e);
+						}
+					} catch (Exception e) {
+						logger.log(Level.WARNING, "Failed to delete BuildConfig in namespace: " + namespace
+								+ " for name: " + buildConfigName, e);
+					} finally {
+						removeJobWithBuildConfig(buildConfig);
+					}
+				}
+			}
+		}
+	}
 
-    public void upsertItem(Item item) {
-        if (item instanceof WorkflowJob) {
-          upsertWorkflowJob((WorkflowJob) item);
-        } else if (item instanceof ItemGroup) {
-          upsertItemGroup((ItemGroup) item);
-        }
-    }
+	public void upsertItem(Item item) {
+		if (item instanceof WorkflowJob) {
+			upsertWorkflowJob((WorkflowJob) item);
+		} else if (item instanceof ItemGroup) {
+			upsertItemGroup((ItemGroup) item);
+		}
+	}
 
-    private void upsertItemGroup(ItemGroup itemGroup) {
-        Collection items = itemGroup.getItems();
-        if (items != null) {
-            for (Object child : items) {
-                if (child instanceof WorkflowJob) {
-                  upsertWorkflowJob((WorkflowJob) child);
-                } else if (child instanceof ItemGroup) {
-                  upsertItemGroup((ItemGroup) child);
-                }
-            }
-        }
-    }
+	private void upsertItemGroup(ItemGroup itemGroup) {
+		Collection items = itemGroup.getItems();
+		if (items != null) {
+			for (Object child : items) {
+				if (child instanceof WorkflowJob) {
+					upsertWorkflowJob((WorkflowJob) child);
+				} else if (child instanceof ItemGroup) {
+					upsertItemGroup((ItemGroup) child);
+				}
+			}
+		}
+	}
 
-    private void upsertWorkflowJob(WorkflowJob job) {
-        BuildConfigProjectProperty property = buildConfigProjectForJob(job);
-        if (property != null) {
-            logger.info("Upsert WorkflowJob " + job.getName() +
-                    " to BuildConfig: "+ property.getNamespace() +
-                    "/" + property.getName() + " in OpenShift");
-            upsertBuildConfigForJob(job, property);
-        }
-    }
+	private void upsertWorkflowJob(WorkflowJob job) {
+		BuildConfigProjectProperty property = buildConfigProjectForJob(job);
+		if (property != null) {
+			logger.info("Upsert WorkflowJob " + job.getName() + " to BuildConfig: " + property.getNamespace() + "/"
+					+ property.getName() + " in OpenShift");
+			upsertBuildConfigForJob(job, property);
+		}
+	}
 
-    /**
-     * Returns the mapping of the jenkins workflow job to a qualified namespace and BuildConfig name
-     */
-    private BuildConfigProjectProperty buildConfigProjectForJob(WorkflowJob job) {
+	/**
+	 * Returns the mapping of the jenkins workflow job to a qualified namespace and
+	 * BuildConfig name
+	 */
+	private BuildConfigProjectProperty buildConfigProjectForJob(WorkflowJob job) {
 
-        BuildConfigProjectProperty property = job.getProperty(BuildConfigProjectProperty.class);
+		BuildConfigProjectProperty property = job.getProperty(BuildConfigProjectProperty.class);
 
-        if (property != null) {
-            if (StringUtils.isNotBlank(property.getNamespace()) && StringUtils.isNotBlank(property.getName())) {
-                logger.info("Found BuildConfigProjectProperty for namespace: " + property.getNamespace() +
-                        " name: " + property.getName());
-                return property;
-            }
-        }
+		if (property != null) {
+			if (StringUtils.isNotBlank(property.getNamespace()) && StringUtils.isNotBlank(property.getName())) {
+				logger.info("Found BuildConfigProjectProperty for namespace: " + property.getNamespace() + " name: "
+						+ property.getName());
+				return property;
+			}
+		}
 
-        String patternRegex = this.jobNamePattern;
-        String jobName = JenkinsUtils.getFullJobName(job);
-        if (StringUtils.isNotEmpty(jobName) && StringUtils.isNotEmpty(patternRegex) && jobName.matches(patternRegex)) {
-            String buildConfigName = OpenShiftUtils.convertNameToValidResourceName(JenkinsUtils.getBuildConfigName(job));
+		String patternRegex = this.jobNamePattern;
+		String jobName = JenkinsUtils.getFullJobName(job);
+		if (StringUtils.isNotEmpty(jobName) && StringUtils.isNotEmpty(patternRegex) && jobName.matches(patternRegex)) {
+			String buildConfigName = OpenShiftUtils
+					.convertNameToValidResourceName(JenkinsUtils.getBuildConfigName(job));
 
-            // we will update the uuid when we create the BC
-            String uuid = null;
+			// we will update the uuid when we create the BC
+			String uuid = null;
 
-            // TODO what to do for the resourceVersion?
-            String resourceVersion = null;
-            String buildRunPolicy = "Serial";
-            for (String namespace: namespaces){
-                logger.info("Creating BuildConfigProjectProperty for namespace: " + namespace + " name: " + buildConfigName);
-                if (property != null) {
-                    property.setNamespace(namespace);
-                    property.setName(buildConfigName);
-                    if (!StringUtils.isNotBlank(property.getBuildRunPolicy())) {
-                        property.setBuildRunPolicy(buildRunPolicy);
-                    }
-                    return property;
-                } else {
-                    return new BuildConfigProjectProperty(namespace, buildConfigName, uuid, resourceVersion, buildRunPolicy);
-                }
-            }
+			// TODO what to do for the resourceVersion?
+			String resourceVersion = null;
+			String buildRunPolicy = "Serial";
+			for (String namespace : namespaces) {
+				logger.info("Creating BuildConfigProjectProperty for namespace: " + namespace + " name: "
+						+ buildConfigName);
+				if (property != null) {
+					property.setNamespace(namespace);
+					property.setName(buildConfigName);
+					if (!StringUtils.isNotBlank(property.getBuildRunPolicy())) {
+						property.setBuildRunPolicy(buildRunPolicy);
+					}
+					return property;
+				} else {
+					return new BuildConfigProjectProperty(namespace, buildConfigName, uuid, resourceVersion,
+							buildRunPolicy);
+				}
+			}
 
-        }
-        return null;
-    }
+		}
+		return null;
+	}
 
-    private void upsertBuildConfigForJob(WorkflowJob job, BuildConfigProjectProperty buildConfigProjectProperty) {
-        boolean create = false;
-        BuildConfig jobBuildConfig = getAuthenticatedOpenShiftClient().buildConfigs().
-                inNamespace(buildConfigProjectProperty.getNamespace()).withName(buildConfigProjectProperty.getName()).get();
-        if (jobBuildConfig == null) {
-            create = true;
-            jobBuildConfig = new BuildConfigBuilder().
-                    withNewMetadata().withName(buildConfigProjectProperty.getName()).
-                    withNamespace(buildConfigProjectProperty.getNamespace()).
-                    addToAnnotations(Annotations.GENERATED_BY, "jenkins").
-                    endMetadata().
-                    withNewSpec().
-                    withNewStrategy().withType("JenkinsPipeline").withNewJenkinsPipelineStrategy().endJenkinsPipelineStrategy().endStrategy().
-                    endSpec().build();
-        } else {
-            ObjectMeta metadata = jobBuildConfig.getMetadata();
-            String uid = buildConfigProjectProperty.getUid();
-            if (metadata != null && StringUtils.isEmpty(uid)) {
-                buildConfigProjectProperty.setUid(metadata.getUid());
-            } else if (metadata != null && !Objects.equal(uid, metadata.getUid())) {
-                // the UUIDs are different so lets ignore this BC
-                return;
-            }
-        }
+	private void upsertBuildConfigForJob(WorkflowJob job, BuildConfigProjectProperty buildConfigProjectProperty) {
+		boolean create = false;
+		BuildConfig jobBuildConfig = getAuthenticatedOpenShiftClient().buildConfigs()
+				.inNamespace(buildConfigProjectProperty.getNamespace()).withName(buildConfigProjectProperty.getName())
+				.get();
+		if (jobBuildConfig == null) {
+			create = true;
+			jobBuildConfig = new BuildConfigBuilder().withNewMetadata().withName(buildConfigProjectProperty.getName())
+					.withNamespace(buildConfigProjectProperty.getNamespace())
+					.addToAnnotations(Annotations.GENERATED_BY, "jenkins").endMetadata().withNewSpec().withNewStrategy()
+					.withType("JenkinsPipeline").withNewJenkinsPipelineStrategy().endJenkinsPipelineStrategy()
+					.endStrategy().endSpec().build();
+		} else {
+			ObjectMeta metadata = jobBuildConfig.getMetadata();
+			String uid = buildConfigProjectProperty.getUid();
+			if (metadata != null && StringUtils.isEmpty(uid)) {
+				buildConfigProjectProperty.setUid(metadata.getUid());
+			} else if (metadata != null && !Objects.equal(uid, metadata.getUid())) {
+				// the UUIDs are different so lets ignore this BC
+				return;
+			}
+		}
 
-        updateBuildConfigFromJob(job, jobBuildConfig);
+		updateBuildConfigFromJob(job, jobBuildConfig);
 
-        if (!hasEmbeddedPipelineOrValidSource(jobBuildConfig)) {
-            // this pipeline has not yet been populated with the git source or an embedded pipeline so lets not create/update a BC yet
-            return;
-        }
+		if (!hasEmbeddedPipelineOrValidSource(jobBuildConfig)) {
+			// this pipeline has not yet been populated with the git source or an embedded
+			// pipeline so lets not create/update a BC yet
+			return;
+		}
 
-        // lets annotate with the job name
-        if (create) {
-            OpenShiftUtils.addAnnotation(jobBuildConfig, Annotations.JENKINS_JOB_PATH, JenkinsUtils.getFullJobName(job));
-        }
+		// lets annotate with the job name
+		if (create) {
+			OpenShiftUtils.addAnnotation(jobBuildConfig, Annotations.JENKINS_JOB_PATH,
+					JenkinsUtils.getFullJobName(job));
+		}
 
-        if (create) {
-            try {
-                BuildConfig bc = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
-                String uid = bc.getMetadata().getUid();
-                buildConfigProjectProperty.setUid(uid);
-            } catch (Exception e) {
-                logger.log(Level.WARNING, "Failed to create BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
-            }
-        } else {
-            try {
-                getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).withName(jobBuildConfig.getMetadata().getName()).cascading(false).replace(jobBuildConfig);
-            } catch (Exception e) {
-                logger.log(Level.WARNING, "Failed to update BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
-            }
-          }
-    }
+		if (create) {
+			try {
+				BuildConfig bc = getAuthenticatedOpenShiftClient().buildConfigs()
+						.inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
+				String uid = bc.getMetadata().getUid();
+				buildConfigProjectProperty.setUid(uid);
+			} catch (Exception e) {
+				logger.log(Level.WARNING,
+						"Failed to create BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
+			}
+		} else {
+			try {
+				getAuthenticatedOpenShiftClient().buildConfigs()
+						.inNamespace(jobBuildConfig.getMetadata().getNamespace())
+						.withName(jobBuildConfig.getMetadata().getName()).cascading(false).replace(jobBuildConfig);
+			} catch (Exception e) {
+				logger.log(Level.WARNING,
+						"Failed to update BuildConfig: " + NamespaceName.create(jobBuildConfig) + ". " + e, e);
+			}
+		}
+	}
 
-    private boolean hasEmbeddedPipelineOrValidSource(BuildConfig buildConfig) {
-        BuildConfigSpec spec = buildConfig.getSpec();
-        if (spec != null) {
-            BuildStrategy strategy = spec.getStrategy();
-            if (strategy != null) {
-                JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
-                if (jenkinsPipelineStrategy != null) {
-                    if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfile())) {
-                        return true;
-                    }
-                    if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfilePath())) {
-                        BuildSource source = spec.getSource();
-                        if (source != null) {
-                            GitBuildSource git = source.getGit();
-                            if (git != null) {
-                                if (StringUtils.isNotBlank(git.getUri())) {
-                                  return true;
-                                }
-                            }
-                            // TODO support other SCMs
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }
+	private boolean hasEmbeddedPipelineOrValidSource(BuildConfig buildConfig) {
+		BuildConfigSpec spec = buildConfig.getSpec();
+		if (spec != null) {
+			BuildStrategy strategy = spec.getStrategy();
+			if (strategy != null) {
+				JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+				if (jenkinsPipelineStrategy != null) {
+					if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfile())) {
+						return true;
+					}
+					if (StringUtils.isNotBlank(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+						BuildSource source = spec.getSource();
+						if (source != null) {
+							GitBuildSource git = source.getGit();
+							if (git != null) {
+								if (StringUtils.isNotBlank(git.getUri())) {
+									return true;
+								}
+							}
+							// TODO support other SCMs
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
 
-    /**
-     * TODO is there a cleaner way to get this class injected with any new configuration from GlobalPluginConfiguration?
-     */
-    private void reconfigure() {
-        GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
-        if (config != null) {
-            this.jobNamePattern = config.getJobNamePattern();
-            this.namespaces = (config.getNamespace()).split(" ");
-            this.server = config.getServer();
-        }
-    }
+	/**
+	 * TODO is there a cleaner way to get this class injected with any new
+	 * configuration from GlobalPluginConfiguration?
+	 */
+	private void reconfigure() {
+		GlobalPluginConfiguration config = GlobalPluginConfiguration.get();
+		if (config != null) {
+			this.jobNamePattern = config.getJobNamePattern();
+			this.namespaces = (config.getNamespace()).split(" ");
+			this.server = config.getServer();
+		}
+	}
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.jenkins.openshiftsync;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.triggers.SafeTimerTask;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import jenkins.util.Timer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient;
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.util.logging.Level.SEVERE;
+
+/**
+ * Watches {@link Secret} objects in Kubernetes and syncs then to Credentials in Jenkins
+ */
+public class SecretWatcher implements Watcher<Secret> {
+  private static final String LABEL_JENKINS = "jenkins";
+  private static final String VALUE_SYNC = "sync";
+
+  private final Logger logger = Logger.getLogger(getClass().getName());
+  private final String[] namespaces;
+  private Watch secretWatch;
+  private ScheduledFuture relister;
+
+  public SecretWatcher(String[] namespaces) {
+    this.namespaces = namespaces;
+  }
+
+  public synchronized void start() {
+    // lets process the initial state
+    logger.info("Now handling startup secrets!!");
+    // lets do this in a background thread to avoid errors like:
+    //  Tried proxying io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration to support a circular dependency, but it is not an interface.
+    Runnable task = new SafeTimerTask() {
+      @Override
+      public void doRun() {
+        for(String namespace:namespaces) {
+          try {
+            logger.fine("listing Secrets resources");
+            final SecretList secrets = getOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).list();
+            onInitialSecrets(secrets);
+            logger.fine("handled Secrets resources");
+            if (secretWatch == null) {
+              secretWatch = getOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).withResourceVersion(secrets.getMetadata().getResourceVersion()).watch(SecretWatcher.this);
+            }
+          } catch (Exception e) {
+            logger.log(SEVERE, "Failed to load Secrets: " + e, e);
+          }
+        }
+
+      }
+    };
+    relister = Timer.get().scheduleAtFixedRate(task, 100, 10 * 1000, TimeUnit.MILLISECONDS);
+  }
+
+  public synchronized void stop() {
+    if (relister != null && !relister.isDone()) {
+      relister.cancel(true);
+      relister = null;
+    }
+    if (secretWatch != null) {
+      secretWatch.close();
+      secretWatch = null;
+    }
+  }
+
+  @Override
+  public synchronized void onClose(KubernetesClientException e) {
+    if (e != null) {
+      logger.warning(e.toString());
+
+      if (e.getStatus() != null && e.getStatus().getCode() == HTTP_GONE) {
+        stop();
+        start();
+      }
+    }
+  }
+
+  private synchronized void onInitialSecrets(SecretList secrets) {
+    List<Secret> items = secrets.getItems();
+    if (items != null) {
+      for (Secret secret : items) {
+        try {
+          upsertCredential(secret);
+        } catch (Exception e) {
+          logger.log(SEVERE, "Failed to update job", e);
+        }
+      }
+    }
+  }
+
+  @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
+  @Override
+  public synchronized void eventReceived(Action action, Secret secret) {
+    try {
+      switch (action) {
+        case ADDED:
+          upsertCredential(secret);
+          break;
+        case DELETED:
+          deleteCredential(secret);
+          break;
+        case MODIFIED:
+          modifyCredential(secret);
+          break;
+      }
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "Caught: " + e, e);
+    }
+  }
+
+  private void upsertCredential(final Secret secret) throws Exception {
+    if (isJenkinsSecret(secret)) {
+      CredentialsUtils.upsertCredential(secret);
+    }
+  }
+
+  private void modifyCredential(Secret secret) throws Exception {
+    if (isJenkinsSecret(secret)) {
+      upsertCredential(secret);
+      return;
+    }
+
+    // no longer a Jenkins build so lets delete it if it exists
+    deleteCredential(secret);
+  }
+
+  private static boolean isJenkinsSecret(Secret secret) {
+    ObjectMeta metadata = secret.getMetadata();
+    if (metadata != null) {
+      String name = metadata.getName();
+      return name != null && !name.isEmpty();
+    }
+    return false;
+  }
+
+  private void deleteCredential(final Secret secret) throws Exception {
+    // TODO should we delete credentials?
+    // if we do then we should update BuildConfigWatcher to do the same
+  }
+}

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient;
 import static java.net.HttpURLConnection.HTTP_GONE;
 import static java.util.logging.Level.SEVERE;
@@ -63,7 +64,7 @@ public class SecretWatcher implements Watcher<Secret> {
         for(String namespace:namespaces) {
           try {
             logger.fine("listing Secrets resources");
-            final SecretList secrets = getOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).list();
+            final SecretList secrets = getAuthenticatedOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).list();
             onInitialSecrets(secrets);
             logger.fine("handled Secrets resources");
             if (secretWatch == null) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
@@ -38,131 +38,137 @@ import static java.net.HttpURLConnection.HTTP_GONE;
 import static java.util.logging.Level.SEVERE;
 
 /**
- * Watches {@link Secret} objects in Kubernetes and syncs then to Credentials in Jenkins
+ * Watches {@link Secret} objects in Kubernetes and syncs then to Credentials in
+ * Jenkins
  */
 public class SecretWatcher implements Watcher<Secret> {
-  private static final String LABEL_JENKINS = "jenkins";
-  private static final String VALUE_SYNC = "sync";
+	private static final String LABEL_JENKINS = "jenkins";
+	private static final String VALUE_SYNC = "sync";
 
-  private final Logger logger = Logger.getLogger(getClass().getName());
-  private final String[] namespaces;
-  private Watch secretWatch;
-  private ScheduledFuture relister;
+	private final Logger logger = Logger.getLogger(getClass().getName());
+	private final String[] namespaces;
+	private Watch secretWatch;
+	private ScheduledFuture relister;
 
-  public SecretWatcher(String[] namespaces) {
-    this.namespaces = namespaces;
-  }
+	public SecretWatcher(String[] namespaces) {
+		this.namespaces = namespaces;
+	}
 
-  public synchronized void start() {
-    // lets process the initial state
-    logger.info("Now handling startup secrets!!");
-    // lets do this in a background thread to avoid errors like:
-    //  Tried proxying io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration to support a circular dependency, but it is not an interface.
-    Runnable task = new SafeTimerTask() {
-      @Override
-      public void doRun() {
-        for(String namespace:namespaces) {
-          try {
-            logger.fine("listing Secrets resources");
-            final SecretList secrets = getAuthenticatedOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).list();
-            onInitialSecrets(secrets);
-            logger.fine("handled Secrets resources");
-            if (secretWatch == null) {
-              secretWatch = getOpenShiftClient().secrets().inNamespace(namespace).withLabel(LABEL_JENKINS, VALUE_SYNC).withResourceVersion(secrets.getMetadata().getResourceVersion()).watch(SecretWatcher.this);
-            }
-          } catch (Exception e) {
-            logger.log(SEVERE, "Failed to load Secrets: " + e, e);
-          }
-        }
+	public synchronized void start() {
+		// lets process the initial state
+		logger.info("Now handling startup secrets!!");
+		// lets do this in a background thread to avoid errors like:
+		// Tried proxying io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration to
+		// support a circular dependency, but it is not an interface.
+		Runnable task = new SafeTimerTask() {
+			@Override
+			public void doRun() {
+				for (String namespace : namespaces) {
+					try {
+						logger.fine("listing Secrets resources");
+						final SecretList secrets = getAuthenticatedOpenShiftClient().secrets().inNamespace(namespace)
+								.withLabel(LABEL_JENKINS, VALUE_SYNC).list();
+						onInitialSecrets(secrets);
+						logger.fine("handled Secrets resources");
+						if (secretWatch == null) {
+							secretWatch = getOpenShiftClient().secrets().inNamespace(namespace)
+									.withLabel(LABEL_JENKINS, VALUE_SYNC)
+									.withResourceVersion(secrets.getMetadata().getResourceVersion())
+									.watch(SecretWatcher.this);
+						}
+					} catch (Exception e) {
+						logger.log(SEVERE, "Failed to load Secrets: " + e, e);
+					}
+				}
 
-      }
-    };
-    relister = Timer.get().scheduleAtFixedRate(task, 100, 10 * 1000, TimeUnit.MILLISECONDS);
-  }
+			}
+		};
+		relister = Timer.get().scheduleAtFixedRate(task, 100, 10 * 1000, TimeUnit.MILLISECONDS);
+	}
 
-  public synchronized void stop() {
-    if (relister != null && !relister.isDone()) {
-      relister.cancel(true);
-      relister = null;
-    }
-    if (secretWatch != null) {
-      secretWatch.close();
-      secretWatch = null;
-    }
-  }
+	public synchronized void stop() {
+		if (relister != null && !relister.isDone()) {
+			relister.cancel(true);
+			relister = null;
+		}
+		if (secretWatch != null) {
+			secretWatch.close();
+			secretWatch = null;
+		}
+	}
 
-  @Override
-  public synchronized void onClose(KubernetesClientException e) {
-    if (e != null) {
-      logger.warning(e.toString());
+	@Override
+	public synchronized void onClose(KubernetesClientException e) {
+		if (e != null) {
+			logger.warning(e.toString());
 
-      if (e.getStatus() != null && e.getStatus().getCode() == HTTP_GONE) {
-        stop();
-        start();
-      }
-    }
-  }
+			if (e.getStatus() != null && e.getStatus().getCode() == HTTP_GONE) {
+				stop();
+				start();
+			}
+		}
+	}
 
-  private synchronized void onInitialSecrets(SecretList secrets) {
-    List<Secret> items = secrets.getItems();
-    if (items != null) {
-      for (Secret secret : items) {
-        try {
-          upsertCredential(secret);
-        } catch (Exception e) {
-          logger.log(SEVERE, "Failed to update job", e);
-        }
-      }
-    }
-  }
+	private synchronized void onInitialSecrets(SecretList secrets) {
+		List<Secret> items = secrets.getItems();
+		if (items != null) {
+			for (Secret secret : items) {
+				try {
+					upsertCredential(secret);
+				} catch (Exception e) {
+					logger.log(SEVERE, "Failed to update job", e);
+				}
+			}
+		}
+	}
 
-  @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
-  @Override
-  public synchronized void eventReceived(Action action, Secret secret) {
-    try {
-      switch (action) {
-        case ADDED:
-          upsertCredential(secret);
-          break;
-        case DELETED:
-          deleteCredential(secret);
-          break;
-        case MODIFIED:
-          modifyCredential(secret);
-          break;
-      }
-    } catch (Exception e) {
-      logger.log(Level.WARNING, "Caught: " + e, e);
-    }
-  }
+	@SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
+	@Override
+	public synchronized void eventReceived(Action action, Secret secret) {
+		try {
+			switch (action) {
+			case ADDED:
+				upsertCredential(secret);
+				break;
+			case DELETED:
+				deleteCredential(secret);
+				break;
+			case MODIFIED:
+				modifyCredential(secret);
+				break;
+			}
+		} catch (Exception e) {
+			logger.log(Level.WARNING, "Caught: " + e, e);
+		}
+	}
 
-  private void upsertCredential(final Secret secret) throws Exception {
-    if (isJenkinsSecret(secret)) {
-      CredentialsUtils.upsertCredential(secret);
-    }
-  }
+	private void upsertCredential(final Secret secret) throws Exception {
+		if (isJenkinsSecret(secret)) {
+			CredentialsUtils.upsertCredential(secret);
+		}
+	}
 
-  private void modifyCredential(Secret secret) throws Exception {
-    if (isJenkinsSecret(secret)) {
-      upsertCredential(secret);
-      return;
-    }
+	private void modifyCredential(Secret secret) throws Exception {
+		if (isJenkinsSecret(secret)) {
+			upsertCredential(secret);
+			return;
+		}
 
-    // no longer a Jenkins build so lets delete it if it exists
-    deleteCredential(secret);
-  }
+		// no longer a Jenkins build so lets delete it if it exists
+		deleteCredential(secret);
+	}
 
-  private static boolean isJenkinsSecret(Secret secret) {
-    ObjectMeta metadata = secret.getMetadata();
-    if (metadata != null) {
-      String name = metadata.getName();
-      return name != null && !name.isEmpty();
-    }
-    return false;
-  }
+	private static boolean isJenkinsSecret(Secret secret) {
+		ObjectMeta metadata = secret.getMetadata();
+		if (metadata != null) {
+			String name = metadata.getName();
+			return name != null && !name.isEmpty();
+		}
+		return false;
+	}
 
-  private void deleteCredential(final Secret secret) throws Exception {
-    // TODO should we delete credentials?
-    // if we do then we should update BuildConfigWatcher to do the same
-  }
+	private void deleteCredential(final Secret secret) throws Exception {
+		// TODO should we delete credentials?
+		// if we do then we should update BuildConfigWatcher to do the same
+	}
 }

--- a/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
@@ -37,8 +37,8 @@
              description="The regular expression to match pipeline job names which should be sync'd to BuildConfigs in OpenShift - leave blank to not sync Jenkins Jobs to OpenShift BuildConfigs.">
       <f:textbox/>
     </f:entry>
-    <f:entry title="Skip organisation prefix" field="skipOrganisationPrefix"
-             description="What organisation name prefix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin. Its common for one user/team to use the same git organisation so prefixing all BuildConfig names with the organisation name can be noisy.">
+    <f:entry title="Skip organization prefix" field="skipOrganizationPrefix"
+             description="What organization name prefix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin. Its common for one user/team to use the same git organization so prefixing all BuildConfig names with the organization name can be noisy.">
       <f:textbox/>
     </f:entry>
     <f:entry title="Skip branch suffix" field="skipBranchSuffix"

--- a/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
@@ -33,5 +33,17 @@
              description="The namespace to sync BuildConfigs with - leave blank to sync with all namespaces. Environment variables in the form ${name} will be expanded.  Multiple namespaces can be listed using a space separator.">
       <f:textbox/>
     </f:entry>
+    <f:entry title="Sync Job Name Pattern " field="jobNamePattern"
+             description="The regular expression to match pipeline job names which should be sync'd to BuildConfigs in OpenShift - leave blank to not sync Jenkins Jobs to OpenShift BuildConfigs.">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Skip organisation prefix" field="skipOrganisationPrefix"
+             description="What organisation name prefix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin. Its common for one user/team to use the same git organisation so prefixing all BuildConfig names with the organisation name can be noisy.">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Skip branch suffix" field="skipBranchSuffix"
+             description="What branch name suffix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin.  Its common to use a common branch name like `master` which we can omit from names to avoid noise.">
+      <f:textbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/test/java/io/fabric8/jenkins/openshiftsync/SafeKubernetesNameTest.java
+++ b/src/test/java/io/fabric8/jenkins/openshiftsync/SafeKubernetesNameTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.jenkins.openshiftsync;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ */
+public class SafeKubernetesNameTest {
+    @Test
+    public void testSafeNames() throws Exception {
+        assertSafeKubernetesName("Foo-Bar", "foo-bar");
+        assertSafeKubernetesName("-Foo-Bar", "foo-bar");
+        assertSafeKubernetesName(".-Foo-Bar", "foo-bar");
+        assertSafeKubernetesName("foo-bar/whatnot", "foo-bar.whatnot");
+        assertSafeKubernetesName("foo-bar123/whatnot1234", "foo-bar123.whatnot1234");
+        assertSafeKubernetesName("foo-bar//whatnot", "foo-bar.whatnot");
+        assertSafeKubernetesName("foo-bar/whatnot_", "foo-bar.whatnot");
+        assertSafeKubernetesName("_*foo-bar/*wh!atnot)", "foo-bar.wh-atnot");
+    }
+
+    public static void assertSafeKubernetesName(String text, String expected) {
+        String actual = OpenShiftUtils.convertNameToValidResourceName(text);
+        //System.out.println("Converted `" + text + "` => `" + actual + "`");
+        assertEquals("Safe name for `" + text + "`", expected, actual);
+    }
+
+}


### PR DESCRIPTION
* Plugin support using a folder for each namespace so that BuildConfigs created via openshift look nice and clean inside Jenkins
* support the syncing of Secrets -> Jenkins Credentials
* added a Build annotation for the namespace jenkins is running inside
* fixes creating BuildConfigs from multibranch jobs and ensuring that the generated BuildConfigs don't generate new Jobs via the BuildWatcher

@jstrachan, I have tested this plugin after rebasing from Openshift master.