### PR TITLE
get build with props from jenkins ui fully working

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
@@ -17,14 +17,20 @@ package io.fabric8.jenkins.openshiftsync;
 
 import hudson.Extension;
 import hudson.model.Action;
+import hudson.model.ParameterValue;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.ParametersAction;
 import hudson.model.Queue;
+import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildRequestBuilder;
+
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static io.fabric8.jenkins.openshiftsync.BuildSyncRunListener.joinPaths;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
@@ -33,6 +39,9 @@ import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getJenkinsURL;
 @Extension
 public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
 
+  private static final Logger LOGGER = Logger.getLogger(BuildDecisionHandler.class.getName());
+  
+  
   @Override
   public boolean shouldSchedule(Queue.Task p, List<Action> actions) {
     if (p instanceof WorkflowJob && !isOpenShiftBuildCause(actions)) {
@@ -45,7 +54,7 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
         String namespace = buildConfigProjectProperty.getNamespace();
         String jobURL = joinPaths(getJenkinsURL(getAuthenticatedOpenShiftClient(), namespace), wj.getUrl());
 
-        getAuthenticatedOpenShiftClient().buildConfigs()
+        Build ret = getAuthenticatedOpenShiftClient().buildConfigs()
           .inNamespace(namespace).withName(buildConfigProjectProperty.getName())
           .instantiate(
             new BuildRequestBuilder()
@@ -53,6 +62,10 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
               .addNewTriggeredBy().withMessage("Triggered by Jenkins job at " + jobURL).and()
               .build()
           );
+        
+        ParametersAction params = dumpParams(actions);        
+        if (params != null && ret != null)
+            BuildToParametersActionMap.add(ret.getMetadata().getName(), params);
         return false;
       }
     }
@@ -60,18 +73,32 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
     return true;
   }
 
-  private boolean isOpenShiftBuildCause(List<Action> actions) {
-    for (Action action : actions) {
-      if (action instanceof CauseAction) {
-        CauseAction causeAction = (CauseAction) action;
-        for (Cause cause : causeAction.getCauses()) {
-          if (cause instanceof BuildCause) {
-            return true;
+  private static boolean isOpenShiftBuildCause(List<Action> actions) {
+      for (Action action : actions) {
+        if (action instanceof CauseAction) {
+          CauseAction causeAction = (CauseAction) action;
+          for (Cause cause : causeAction.getCauses()) {
+            if (cause instanceof BuildCause) {
+              return true;
+            }
           }
         }
       }
+      return false;
     }
-    return false;
-  }
 
+  private static ParametersAction dumpParams(List<Action> actions) {
+      for (Action action : actions) {
+        if (action instanceof ParametersAction) {
+            ParametersAction paramAction = (ParametersAction) action;
+            if (LOGGER.isLoggable(Level.FINE))
+              for (ParameterValue param : paramAction.getAllParameters()) {
+                  LOGGER.fine("param name " + param.getName() + " param value " + param.getValue());
+              }
+          return paramAction;
+        }
+      }
+      return null;
+    }
+  
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToParametersActionMap.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToParametersActionMap.java
@@ -1,0 +1,29 @@
+package io.fabric8.jenkins.openshiftsync;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import hudson.model.ParametersAction;
+
+public class BuildToParametersActionMap {
+    
+    private static Map<String, ParametersAction> buildToParametersMap;
+
+    private BuildToParametersActionMap() {
+    }
+    
+    static synchronized void initialize() {
+        if (buildToParametersMap == null) {
+            buildToParametersMap = new ConcurrentHashMap<String, ParametersAction>();
+        }
+    }
+    
+    static synchronized void add(String buildId, ParametersAction params) {
+        buildToParametersMap.put(buildId, params);
+    }
+    
+    static synchronized ParametersAction remove(String buildId) {
+        return buildToParametersMap.remove(buildId);
+    }
+
+}

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -66,6 +66,7 @@ public class BuildWatcher implements Watcher<Build> {
   }
 
   public void start() {
+    BuildToParametersActionMap.initialize();
     // lets do this in a background thread to avoid errors like:
     //  Tried proxying io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration to support a circular dependency, but it is not an interface.
     Runnable task = new SafeTimerTask() {


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/14369

since it is a cross repo situation, I am going to close out the origin issue once @mangirdaz has a chance to respond wrt trying out the patch I provided

we'll then subsequently track things with this PR

So the basic history:
- builds with parameters were originally non-functional with sync plugin
- I partially addressed it with the pipeline strategy env var work, but only the default values were applied
- with this PR I figured out how to apply the parameter values supplied by the user from the Jenkins UI (or via the analogous http post) to the job submission

@openshift/devex - FYI