### PR TITLE
fix IST pod template processing

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
@@ -15,20 +15,14 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
-import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.initializeBuildConfigToJobMap;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static java.net.HttpURLConnection.HTTP_GONE;
-import static java.util.logging.Level.SEVERE;
-import hudson.triggers.SafeTimerTask;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.openshift.api.model.BuildConfigList;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -594,10 +594,27 @@ public class JenkinsUtils {
     public static List<PodTemplate> getPodTemplates() {
         KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
         if(kubeCloud != null){
-          return kubeCloud.getTemplates();
+          // create copy of list for more flexiblity in loops
+          ArrayList<PodTemplate> list = new ArrayList<PodTemplate>();
+          list.addAll(kubeCloud.getTemplates());
+          return list;
         } else {
           return null;
         }
+      }
+    
+    public static boolean hasPodTemplate(String name) {
+        if (name == null)
+            return false;
+        KubernetesCloud kubeCloud = JenkinsUtils.getKubernetesCloud();
+        if(kubeCloud != null){
+          List<PodTemplate> list = kubeCloud.getTemplates();
+          for (PodTemplate pod : list) {
+              if (name.equals(pod.getName()))
+                  return true;
+          }
+        }
+        return false;
       }
     
     public static void addPodTemplate(PodTemplate podTemplate) {


### PR DESCRIPTION
@openshift/devex 

for the soon to be arriving QE bugzilla based on testing for https://trello.com/c/hS9lzo1v/1202-5-better-jenkins-slave-template-configuration-jenkinsintegration

turns out, maintaining a local cache of image stream plus image stream tag pod templates was counter productive; instead, we leverage the k8s plugin collection of pod templates (which are backed to disk), working around the issue I discovered wrt PodTemplate not properly overriding hash() and equals() for manipulation within collections.