### PR TITLE
throttle jenkins status to openshift build updates

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
@@ -34,6 +34,12 @@ public class BuildCause extends Cause {
   private String commit;
 
   private String buildConfigUid;
+  
+  private int numStages = -1;
+  
+  private int numFlowNodes = -1;
+  
+  private long lastUpdateToOpenshift = -1;
 
   public BuildCause(String uid, String namespace, String name, String gitUri, String commit, String buildConfigUid) {
     this.uid = uid;
@@ -42,6 +48,13 @@ public class BuildCause extends Cause {
     this.gitUri = gitUri;
     this.commit = commit;
     this.buildConfigUid = buildConfigUid;
+  }
+  
+  public BuildCause(String uid, String namespace, String name, String gitUri, String commit, String buildConfigUid, int numStages, int numFlowNodes, long lastUpdateToOpenshift) {
+      this( uid,  namespace,  name,  gitUri,  commit,  buildConfigUid);
+      this.numStages = numStages;
+      this.numFlowNodes = numFlowNodes;
+      this.lastUpdateToOpenshift = lastUpdateToOpenshift;
   }
 
   public BuildCause(Build build, String buildConfigUid) {
@@ -104,4 +117,30 @@ public class BuildCause extends Cause {
   public String getBuildConfigUid() {
     return buildConfigUid;
   }
+
+public int getNumStages() {
+    return numStages;
+}
+
+public void setNumStages(int numStages) {
+    this.numStages = numStages;
+}
+
+public int getNumFlowNodes() {
+    return numFlowNodes;
+}
+
+public void setNumFlowNodes(int numFlowNodes) {
+    this.numFlowNodes = numFlowNodes;
+}
+
+public long getLastUpdateToOpenshift() {
+    return lastUpdateToOpenshift;
+}
+
+public void setLastUpdateToOpenshift(long lastUpdateToOpenshift) {
+    this.lastUpdateToOpenshift = lastUpdateToOpenshift;
+}
+  
+
 }


### PR DESCRIPTION
bug 1475867
https://bugzilla.redhat.com/show_bug.cgi?id=1475867

@openshift/devex @spadgett FYI

adds both time and state based throttling; all of whose details are certainly negotiable

in my testing, the openshift web console still seems to render stages OK, but certainly it is "choppier" than before

there's comments explaining the various conditions, but I'll summarize here:
1) no poll jenkins job run status every 10 seconds (vs. 1 second) in addition to listening to jenkins events
2) will update the build if
   a) an update has not been made in 30 seconds
   b) the number of stages or flow nodes changes 
   c) the job run reaches a terminal state

