### PR TITLE
bump fabric, which also bumps okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
          ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
          ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
     -->
-    <openshift-client.version>2.1.2</openshift-client.version>
+    <openshift-client.version>2.3.1</openshift-client.version>
     <log.level>INFO</log.level>
     <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>


### PR DESCRIPTION
@openshift/devex fyi

this current latest fabric version also bumps okkhttp to current latest 3.8.1

@jstrachan - any guidance on where I should look or who I should talk to wrt whether v2.6.1 of fabric's openshift-client is OK?  Or if not, which level to upgrade to.

v2.1.2 seemed stale and https://github.com/openshift/jenkins-plugin/issues/147 has motivated me to bump a series of key dependencies for our jenkins plugins

thanks