### PR TITLE
implement a build cache for build watch events that come before bc ev…

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -55,7 +55,7 @@ public class BuildConfigToJobMapper {
 
     public static FlowDefinition mapBuildConfigToFlow(BuildConfig bc)
             throws IOException {
-        if (!OpenShiftUtils.isJenkinsBuildConfig(bc)) {
+        if (!OpenShiftUtils.isPipelineStrategyBuildConfig(bc)) {
             return null;
         }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -99,6 +99,10 @@ public class BuildConfigWatcher extends BaseWatcher implements
                                 e);
                     }
                 }
+                // poke the BuildWatcher builds with no BC list and see if we
+                // can create job
+                // runs for premature builds
+                BuildWatcher.flushBuildsWithNoBCList();
             }
         };
     }
@@ -139,6 +143,10 @@ public class BuildConfigWatcher extends BaseWatcher implements
                 modifyEventToJenkinsJob(buildConfig);
                 break;
             }
+            // if bc event came after build events, let's
+            // poke the BuildWatcher builds with no BC list to create job
+            // runs
+            BuildWatcher.flushBuildsWithNoBCList();
         } catch (Exception e) {
             logger.log(Level.WARNING, "Caught: " + e, e);
         }
@@ -163,7 +171,7 @@ public class BuildConfigWatcher extends BaseWatcher implements
     }
 
     private void upsertJob(final BuildConfig buildConfig) throws Exception {
-        if (isJenkinsBuildConfig(buildConfig)) {
+        if (isPipelineStrategyBuildConfig(buildConfig)) {
             // sync on intern of name should guarantee sync on same actual obj
             synchronized (buildConfig.getMetadata().getUid().intern()) {
                 ACL.impersonate(ACL.SYSTEM,
@@ -298,7 +306,7 @@ public class BuildConfigWatcher extends BaseWatcher implements
 
     private synchronized void modifyEventToJenkinsJob(BuildConfig buildConfig)
             throws Exception {
-        if (isJenkinsBuildConfig(buildConfig)) {
+        if (isPipelineStrategyBuildConfig(buildConfig)) {
             upsertJob(buildConfig);
             return;
         }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -623,6 +623,8 @@ public class JenkinsUtils {
         boolean jobIsBuilding = job.isBuilding();
         for (int i = 0; i < builds.size(); i++) {
             Build b = builds.get(i);
+            if (!OpenShiftUtils.isPipelineStrategyBuild(b))
+                continue;
             // For SerialLatestOnly we should try to cancel all builds before
             // the latest one requested.
             if (isSerialLatestOnly) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -124,7 +124,7 @@ public class OpenShiftUtils {
      * @return true if this is an OpenShift BuildConfig which should be mirrored
      *         to a Jenkins Job
      */
-    public static boolean isJenkinsBuildConfig(BuildConfig bc) {
+    public static boolean isPipelineStrategyBuildConfig(BuildConfig bc) {
         if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY
                 .equalsIgnoreCase(bc.getSpec().getStrategy().getType())
                 && bc.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
@@ -141,6 +141,15 @@ public class OpenShiftUtils {
             }
         }
 
+        return false;
+    }
+
+    public static boolean isPipelineStrategyBuild(Build b) {
+        if (BuildConfigToJobMapper.JENKINS_PIPELINE_BUILD_STRATEGY
+                .equalsIgnoreCase(b.getSpec().getStrategy().getType())
+                && b.getSpec().getStrategy().getJenkinsPipelineStrategy() != null) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
…ents for bc creation, then trigger build job when bc arrives

@openshift/devex FYI

@csrwng looks to have hit timing windows where the build watch events arrive before bc watch events when both are created more or less simultaneously; if that happens, the job run in jenkins for that pipeline build won't get triggered until the next watch relist action

when the watch relist interval was 10 seconds, it was not big deal.... but it is now 5 minutes ... enough time for users to get impatient / wonder what is wrong ;-) 