### PR TITLE
Adding support for secrets in build config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>io.fabric8.jenkins.plugins</groupId>
   <artifactId>openshift-sync</artifactId>
-  <version>0.1.31-SNAPSHOT</version>
+  <version>0.1.32-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
 
     public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
     public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
+    public static final String OPENSHIFT_SECRETS_DATA_P12_DATA = "p12";
     public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
     public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
     public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -84,6 +84,7 @@ import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_B
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_NAME;
 import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
+import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSecretData;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
 import static java.util.Collections.sort;
 import static java.util.logging.Level.SEVERE;
@@ -326,6 +327,7 @@ public class JenkinsUtils {
         // sync on intern of name should guarantee sync on same actual obj
         synchronized (buildConfig.getMetadata().getUid().intern()) {
             updateSourceCredentials(buildConfig);
+            updateSecretData(buildConfig);
 
             // We need to ensure that we do not remove
             // existing Causes from a Run since other


### PR DESCRIPTION
Allow secrets from the build config to be synced to Jenkins credentials. 

When a buildconfig has the following entry:
```
source:
    secrets:
      - secret:
          name: <secret-name>
```

This code will pick up those secrets, and any that it knows how to convert to credentials will be added as credentials.

This code also implements sync for credential secrets. For this to function, the secret must have a `p12` and `password` field.

The p12 field must be a password-protected p12 keystore in base64 encoding.
The password field must be the password used to protect the keystore.

Any thoughts or comments are very welcome.