### PR TITLE
fix status json for declarative stages that are skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+       <groupId>io.jenkins.blueocean</groupId>
+       <artifactId>blueocean-rest</artifactId>
+       <version>1.1.6</version>
+    </dependency>
+
+    <dependency>
        <groupId>org.jenkins-ci.plugins</groupId>
        <artifactId>credentials</artifactId>
        <version>2.1.9</version>


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/2509

@openshift/sig-developer-experience @spadgett fyi / ptal

This change takes the minimalist approach of duplicating what was done for tranditional/scripted pipelines, where any skipped stages simply were not included in the status json

A slight enhancement for declarative would be to included the stage, but override the incorrect successful status provide by the base pipeline support we are using for the json but switch it to StatusExt.NOT_EXECUTED.  The origin-web-console could then interpret this as a stage being skipped and display accordingly.

Larger changes would be further investigation into the bevy of (ever evolving) blueocean apis to obtain the full json payload blueocean leverages (the new format @spadgett noted in the issue) and then augment origin-web-console.  

My current stance is that the large changes (and probably the slight enhancement as well) are outside the scope of this PR.