### PR TITLE
switch IS based auto pod template cfg to always pull image

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -800,7 +800,7 @@ public class JenkinsUtils {
 		// podTemplate.setInstanceCap(Integer.MAX_VALUE);
 		podTemplate.setName(name);
 		podTemplate.setLabel(label);
-		podTemplate.setAlwaysPullImage(false);
+		podTemplate.setAlwaysPullImage(true);
 		podTemplate.setCommand("");
 		podTemplate.setArgs("${computer.jnlpmac} ${computer.name}");
 		podTemplate.setRemoteFs("/tmp");


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-sync-plugin/issues/186

@openshift/sig-developer-experience fyi

note, this method is only called in the image watch case 