### PR TITLE
Delete Jenkins job run when build is deleted from OpenShift

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -24,10 +24,12 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildList;
 import io.fabric8.openshift.api.model.BuildStatus;
+import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,11 +47,17 @@ import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBui
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_BUILD_NUMBER;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
+
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.cancelBuild;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.deleteRun;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.getJobFromBuild;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.handleBuildList;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.triggerJob;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancellable;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isNew;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.updateOpenShiftBuildPhase;
 import static java.util.logging.Level.WARNING;
 
 public class BuildWatcher extends BaseWatcher implements Watcher<Build> {
@@ -129,6 +137,7 @@ public class BuildWatcher extends BaseWatcher implements Watcher<Build> {
                                 "Failed to load initial Builds: " + e, e);
                     }
                 }
+                reconcileRunsAndBuilds();
             }
         };
     }
@@ -414,4 +423,41 @@ public class BuildWatcher extends BaseWatcher implements Watcher<Build> {
         // clean up
         innerDeleteEventToJenkinsJobRun(build);
     }
+
+  /**
+   * Reconciles Jenkins job runs and OpenShift builds
+   *
+   * Deletes all job runs that do not have an associated build in OpenShift
+   */
+  private static synchronized void reconcileRunsAndBuilds() {
+    logger.info("Reconciling job runs and builds");
+
+    List<WorkflowJob> jobs = Jenkins.getActiveInstance().getAllItems(WorkflowJob.class);
+
+    for (WorkflowJob job : jobs) {
+      BuildConfigProjectProperty bcpp = job.getProperty(BuildConfigProjectProperty.class);
+      if (bcpp == null) {
+        // If we encounter a job without a BuildConfig, skip the reconciliation logic
+        continue;
+      }
+      BuildList buildList = getAuthenticatedOpenShiftClient().builds()
+        .inNamespace(bcpp.getNamespace()).withLabel("buildconfig=" + bcpp.getName()).list();
+
+      logger.info("Checking runs for BuildConfig " + bcpp.getNamespace() + "/" + bcpp.getName());
+
+      for (WorkflowRun run : job.getBuilds()) {
+        boolean found = false;
+        BuildCause cause = run.getCause(BuildCause.class);
+        for (Build build : buildList.getItems()) {
+          if (cause != null && cause.getUid().equals(build.getMetadata().getUid())) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          deleteRun(run);
+        }
+      }
+    }
+  }
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -64,7 +64,6 @@ import com.cloudbees.plugins.credentials.CredentialsParameterDefinition;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -114,7 +113,7 @@ public class JenkinsUtils {
 		}
 		return root;
 	}
-	
+
 	public static boolean verifyEnvVars(Map<String, ParameterDefinition> paramMap, WorkflowJob workflowJob) {
         if (paramMap != null) {
             String fullName = workflowJob.getFullName();
@@ -443,10 +442,11 @@ public class JenkinsUtils {
 
 	public synchronized static void cancelBuild(WorkflowJob job, Build build, boolean deleted) {
 		if (!cancelQueuedBuild(job, build)) {
-			cancelRunningBuild(job, build);
+      cancelRunningBuild(job, build);
 		}
-		if (deleted)
+		if (deleted) {
 			return;
+		}
 		try {
 			updateOpenShiftBuildPhase(build, CANCELLED);
 		} catch (Exception e) {
@@ -469,6 +469,15 @@ public class JenkinsUtils {
 			}
 		}
 		return null;
+	}
+
+	public synchronized static void deleteRun(WorkflowRun run) {
+			try {
+			  LOGGER.info("Deleting run: " + run.toString());
+				run.delete();
+			} catch (IOException e) {
+				LOGGER.warning("Unable to delete run " + run.toString() + ":" + e.getMessage());
+			}
 	}
 
 	private static boolean cancelRunningBuild(WorkflowJob job, Build build) {


### PR DESCRIPTION
 - Updates the openshift-client version from 2.3.1 to 3.0.3
 - Jenkins will no longer remove the successfulBuildsHistoryLimit and failedBuildsHistoryLimit from the BuildConfig
 - Jenkins job runs will be deleted if/when the associated build is deleted from OpenShift
- Fixed a couple of small indent issues

Fixes #201 