### PR TITLE
update run poll based on OSIO issue; doc polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Development Instructions
 * Install the plugin into a locally-running Jenkins
   Execute `mvn hpi:run`
   Navigate in brower to `http://localhost:8080/jenkins`
+  
+Synchronization Polling Frequencies
+-----------------------------------
+
+* Jenkins Run to OpenShift Build Sync: 5 seconds [BuildSyncRunListener](https://github.com/openshift/jenkins-sync-plugin/blob/master/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java)
+  
+* OpenShift Resource Relist (backup for missed Watch events): 5 minutes [BaseWatcher](https://github.com/openshift/jenkins-sync-plugin/blob/master/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java)

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -88,7 +88,8 @@ public class BuildSyncRunListener extends RunListener<Run> {
     private static final Logger logger = Logger
             .getLogger(BuildSyncRunListener.class.getName());
 
-    private long pollPeriodMs = 1000;
+    private long pollPeriodMs = 1000 * 5;  // 5 seconds
+    private long delayPollPeriodMs = 1000; // 1 seconds
     private static final long maxDelay = 30000;
 
     private transient Set<Run> runsToPoll = new CopyOnWriteArraySet<>();
@@ -159,7 +160,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
                     pollLoop();
                 }
             };
-            Timer.get().scheduleAtFixedRate(task, pollPeriodMs, pollPeriodMs,
+            Timer.get().scheduleAtFixedRate(task, delayPollPeriodMs, pollPeriodMs,
                     TimeUnit.MILLISECONDS);
         }
     }


### PR DESCRIPTION
Pulled in https://github.com/fabric8io/jenkins-sync-plugin/pull/16
See 
- https://github.com/fabric8io/jenkins-sync-plugin/issues/14
- https://github.com/openshiftio/openshift.io/issues/1648

@openshift/sig-developer-experience @hrishin @rupalibehera fyi

historical note: we previously had adjusted the resource relist interval based on a similar observation in our online starter environments; most likely there were not enough actual pipeline jobs getting kicked off in the non-OSIO envs to uncover this one yet.