### PR TITLE
Flush the build HashSet directly without clone it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,11 @@
 		 <artifactId>kubernetes</artifactId>
 		 <version>0.10</version>
 	</dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>9.3.7.v20160115</version>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
originally in order to flush the build HashSet, the HashSet was cloned
in order to handle the right builds.
this clone theoretically holds references that can't be collected by the GC.

using the build HashSet directly potentially can save some memory.

by testing this PR, I found nicer heap memory, and about ~20mb less than usual.