### PR TITLE
Cfg list interval

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
@@ -43,6 +43,8 @@ public abstract class BaseWatcher {
 
     public abstract Runnable getStartTimerTask();
     
+    public abstract int getListIntervalInSeconds();
+    
     public abstract <T> void eventReceived(io.fabric8.kubernetes.client.Watcher.Action action, T resource);
 
     public synchronized void start() {
@@ -54,8 +56,7 @@ public abstract class BaseWatcher {
         relister = Timer.get().scheduleAtFixedRate(task, 100, // still do the
                                                               // first run 100
                                                               // milliseconds in
-                5 * 60 * 1000, // 1000 ms * 60 seconds * 5 minutes between
-                               // subsequent runs
+                getListIntervalInSeconds() * 1000,
                 TimeUnit.MILLISECONDS);
     }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -95,6 +95,11 @@ public class BuildConfigWatcher extends BaseWatcher {
         super(namespaces);
     }
 
+    @Override
+    public int getListIntervalInSeconds() {
+        return GlobalPluginConfiguration.get().getBuildConfigListInterval();
+    }
+
     public Runnable getStartTimerTask() {
         return new SafeTimerTask() {
             @Override

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -82,6 +82,11 @@ public class BuildWatcher extends BaseWatcher {
     }
 
     @Override
+    public int getListIntervalInSeconds() {
+        return GlobalPluginConfiguration.get().getBuildListInterval();
+    }
+
+    @Override
     public Runnable getStartTimerTask() {
         return new SafeTimerTask() {
             @Override

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapWatcher.java
@@ -50,6 +50,11 @@ public class ConfigMapWatcher extends BaseWatcher {
         this.trackedConfigMaps = new ConcurrentHashMap<>();
     }
 
+    @Override
+    public int getListIntervalInSeconds() {
+        return GlobalPluginConfiguration.get().getConfigMapListInterval();
+    }
+
     public Runnable getStartTimerTask() {
         return new SafeTimerTask() {
             @Override

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -233,24 +233,32 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 				.includeCurrentValue(credentialsId);
 	}
 
-	private void configChange() {
+	private synchronized void configChange() {
+	    logger.info("OpenShift Sync Plugin processing a newly supplied configuration");
+        if (buildConfigWatcher != null) {
+            buildConfigWatcher.stop();
+        }
+        if (buildWatcher != null) {
+            buildWatcher.stop();
+        }
+        if (configMapWatcher != null) {
+            configMapWatcher.stop();
+        }
+        if (imageStreamWatcher != null) {
+            imageStreamWatcher.stop();
+        }
+        if (secretWatcher != null) {
+            secretWatcher.stop();
+        }
+        buildWatcher = null;
+        buildConfigWatcher = null;
+        configMapWatcher = null;
+        imageStreamWatcher = null;
+        secretWatcher = null;
+        OpenShiftUtils.shutdownOpenShiftClient();
+        
 		if (!enabled) {
-			if (buildConfigWatcher != null) {
-				buildConfigWatcher.stop();
-			}
-			if (buildWatcher != null) {
-				buildWatcher.stop();
-			}
-			if (configMapWatcher != null) {
-				configMapWatcher.stop();
-			}
-			if (imageStreamWatcher != null) {
-				imageStreamWatcher.stop();
-			}
-			if (secretWatcher != null) {
-			    secretWatcher.stop();
-			}
-			OpenShiftUtils.shutdownOpenShiftClient();
+		    logger.info("OpenShift Sync Plugin has been disabled");
 			return;
 		}
 		try {
@@ -260,7 +268,7 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 			Runnable task = new SafeTimerTask() {
 				@Override
 				protected void doRun() throws Exception {
-					logger.info("Waiting for Jenkins to be started");
+					logger.info("Confirming Jenkins is started");
 					while (true) {
 						final Jenkins instance = Jenkins.getActiveInstance();
 						// We can look at Jenkins Init Level to see if we are

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -57,6 +57,12 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 
 	private String skipBranchSuffix;
 
+    private int buildListInterval = 300;
+    private int buildConfigListInterval = 300;
+    private int secretListInterval = 300;
+    private int configMapListInterval = 300;
+    private int imageStreamListInterval = 300;
+    
 	private transient BuildWatcher buildWatcher;
 
 	private transient BuildConfigWatcher buildConfigWatcher;
@@ -69,7 +75,9 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 
 	@DataBoundConstructor
 	public GlobalPluginConfiguration(boolean enable, String server, String namespace, String credentialsId,
-			String jobNamePattern, String skipOrganizationPrefix, String skipBranchSuffix) {
+			String jobNamePattern, String skipOrganizationPrefix, String skipBranchSuffix,
+			int buildListInterval, int buildConfigListInterval, int configMapListInterval,
+			int secretListInterval, int imageStreamListInterval) {
 		this.enabled = enable;
 		this.server = server;
 		this.namespaces = StringUtils.isBlank(namespace) ? null : namespace.split(" ");
@@ -77,6 +85,11 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 		this.jobNamePattern = jobNamePattern;
 		this.skipOrganizationPrefix = skipOrganizationPrefix;
 		this.skipBranchSuffix = skipBranchSuffix;
+		this.buildListInterval = buildListInterval;
+		this.buildConfigListInterval = buildConfigListInterval;
+		this.configMapListInterval = configMapListInterval;
+		this.secretListInterval = secretListInterval;
+		this.imageStreamListInterval = imageStreamListInterval;
 		configChange();
 	}
 
@@ -161,7 +174,47 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 		this.skipBranchSuffix = skipBranchSuffix;
 	}
 
-	// https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
+    public int getBuildListInterval() {
+        return buildListInterval;
+    }
+
+    public void setBuildListInterval(int buildListInterval) {
+        this.buildListInterval = buildListInterval;
+    }
+
+    public int getBuildConfigListInterval() {
+        return buildConfigListInterval;
+    }
+
+    public void setBuildConfigListInterval(int buildConfigListInterval) {
+        this.buildConfigListInterval = buildConfigListInterval;
+    }
+
+    public int getSecretListInterval() {
+        return secretListInterval;
+    }
+
+    public void setSecretListInterval(int secretListInterval) {
+        this.secretListInterval = secretListInterval;
+    }
+
+    public int getConfigMapListInterval() {
+        return configMapListInterval;
+    }
+
+    public void setConfigMapListInterval(int configMapListInterval) {
+        this.configMapListInterval = configMapListInterval;
+    }
+
+    public int getImageStreamListInterval() {
+        return imageStreamListInterval;
+    }
+
+    public void setImageStreamListInterval(int imageStreamListInterval) {
+        this.imageStreamListInterval = imageStreamListInterval;
+    }
+
+    // https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
 	// http://javadoc.jenkins-ci.org/credentials/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.html
 	// https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java
 	public static ListBoxModel doFillCredentialsIdItems(String credentialsId) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamWatcher.java
@@ -48,6 +48,11 @@ public class ImageStreamWatcher extends BaseWatcher {
         this.predefinedOpenShiftSlaves.add("nodejs");
     }
 
+    @Override
+    public int getListIntervalInSeconds() {
+        return GlobalPluginConfiguration.get().getImageStreamListInterval();
+    }
+
     public Runnable getStartTimerTask() {
         return new SafeTimerTask() {
             @Override

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretWatcher.java
@@ -47,6 +47,11 @@ public class SecretWatcher extends BaseWatcher {
     }
 
     @Override
+    public int getListIntervalInSeconds() {
+        return GlobalPluginConfiguration.get().getSecretListInterval();
+    }
+
+    @Override
     public Runnable getStartTimerTask() {
         return new SafeTimerTask() {
             @Override

--- a/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
@@ -45,5 +45,25 @@
              description="What branch name suffix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin.  Its common to use a common branch name like `master` which we can omit from names to avoid noise.">
       <f:textbox/>
     </f:entry>
+    <f:entry title="Build list interval" field="buildListInterval"
+             description="Time in seconds the sync plugin runs a list operation for builds">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Build config list interval" field="buildConfigListInterval"
+             description="Time in seconds the sync plugin runs a list operation for builds configs">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Config map list interval" field="configMapListInterval"
+             description="Time in seconds the sync plugin runs a list operation for config maps">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Image stream list interval" field="imageStreamListInterval"
+             description="Time in seconds the sync plugin runs a list operation for image streams">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="Secret list interval" field="secretListInterval"
+             description="Time in seconds the sync plugin runs a list operation for secrets">
+      <f:textbox/>
+    </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-sync-plugin/issues/209

Provides mitigation / workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1554902 along with recent changes to attempt retry on closed watch connections and better log when watch connections close on us unexpectedly

Currently, it appears in both the above github issues and bugzilla, based on the data collected, that watch events for created builds can stop arriving, and with the current default of 5 minutes on relist, the user has to wait a long time for the build to start.

Also, as part of doing this change, found a separate problem where our watchers/listers would leak on any config change.  Fixing that as well.

@openshift/sig-developer-experience fyi / ptal if you have cycles today