### PR TITLE
Add sync of Openshift opaque secrets to Jenkins file credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ the Jenkins Credentials Plugin.
 * changes in OpenShift ConfigMap resources are examined for XML documents that correspond to Pod Template configuration for the Kubernetes Cloud plugin at http://github.com/jenkinsci/kubernetes-plugin and change the configuration of the Kuberentes Cloud plugin running in Jenkins to add, edit, or remove Pod Templates based on what exists in the ConfigMap; also note, if the <image></image> setting of the Pod Template starts with "imagestreamtag:", then this plugin will look up the ImageStreamTag for that entry (stripping "imagestreamtag:" first) and if found, replace the entry with the ImageStreamTag's Docker image reference.
 * changes to OpenShift ImageStream resources with the label "role" set to "jenkins-slave" and ImageStreamTag resources with the annotation "role" set to "jenkins-slave" are considered images to used with Pod Templates for the Kubernetes Cloud plugin, where the Pod Templates are added, modified, or deleted from the Kubernetes cloud plugin as corresponding ImageStreams and ImageStreamTags are added, modified, or deleted, or have the "role=jenkins-slave" setting changed.
 * changes to OpenShift Secrets with the label "credential.sync.jenkins.openshift.io" set to "true" will result in those Secrets getting coverted into Jenkins Credentials that are registered with the Jenkins Credentials Plugin.
+ * For a Jenkins Secret File credential, the secret requires the 'filename' attribute. See the example below:
+
+```bash
+# Create the secret
+oc create secret generic mysecretfile --from-file=filename=mysecret.txt
+# Add label to mark that it should be synced.
+oc label secret mysecretfile credential.sync.jenkins.openshift.io=true
+```
+
+```groovy
+// the credential will be created by the plugin with the name '<namespace>-<secretname>'
+withCredentials([file(credentialsId: 'namespace-mysecretfile', variable: 'MYFILE')]) {
+ sh '''
+   #!/bin/bash
+   cp ${MYFILE} newsecretfile.txt
+ '''
+}
+```
 
 Development Instructions
 ------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,11 @@
       <artifactId>jetty-util</artifactId>
       <version>9.3.7.v20160115</version>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plain-credentials</artifactId>
+        <version>1.3</version>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
 	public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
 	public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
 	public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
+	public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
 	public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
 	public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
 	public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";


### PR DESCRIPTION
- Opaque secrets can now be synced provided they have a filename attribute

```
oc create secret generic mysecretfile --from-file=filename=mysecret.txt
oc label secret mysecretfile credential.sync.jenkins.openshift.io=true
```
```
// In Jenkinsfile
// the credential will be created by the plugin with the name '<namespace>-<secretname>'
withCredentials([file(credentialsId: 'namespace-mysecretfile', variable: 'MYFILE')]) {
 sh '''
   #!/bin/bash
   cp ${MYFILE} newsecretfile.txt
 '''
}
```