### PR TITLE
Reconcile running on non-openshift pipeline builds

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
@@ -42,9 +42,9 @@ public abstract class BaseWatcher {
     }
 
     public abstract Runnable getStartTimerTask();
-    
+
     public abstract int getListIntervalInSeconds();
-    
+
     public abstract <T> void eventReceived(io.fabric8.kubernetes.client.Watcher.Action action, T resource);
 
     public synchronized void start() {
@@ -74,7 +74,7 @@ public abstract class BaseWatcher {
 
     public synchronized void onClose(KubernetesClientException e, String namespace) {
         //scans of fabric client confirm this call be called with null
-        //we do not want to totally ignore this, as the closing of the 
+        //we do not want to totally ignore this, as the closing of the
         //watch can effect responsiveness
         LOGGER.info("Watch for type " + this.getClass().getName() + " closed for one of the following namespaces: " + watches.keySet().toString());
         if (e != null) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -470,15 +470,15 @@ public class BuildWatcher extends BaseWatcher {
     List<WorkflowJob> jobs = Jenkins.getActiveInstance().getAllItems(WorkflowJob.class);
 
     for (WorkflowJob job : jobs) {
-      BuildConfigProjectProperty bcpp = job.getProperty(BuildConfigProjectProperty.class);
-      if (bcpp == null) {
-        // If we encounter a job without a BuildConfig, skip the reconciliation logic
+      BuildConfigProjectProperty property = job.getProperty(BuildConfigProjectProperty.class);
+      if (property == null || StringUtils.isBlank(property.getNamespace()) || StringUtils.isBlank(property.getName())) {
         continue;
       }
-      BuildList buildList = getAuthenticatedOpenShiftClient().builds()
-        .inNamespace(bcpp.getNamespace()).withLabel("buildconfig=" + bcpp.getName()).list();
 
-      logger.info("Checking runs for BuildConfig " + bcpp.getNamespace() + "/" + bcpp.getName());
+      logger.info("Checking job " + job.toString() + " runs for BuildConfig " + property.getNamespace() + "/" + property.getName());
+
+      BuildList buildList = getAuthenticatedOpenShiftClient().builds()
+        .inNamespace(property.getNamespace()).withLabel("buildconfig=" + property.getName()).list();
 
       for (WorkflowRun run : job.getBuilds()) {
         boolean found = false;


### PR DESCRIPTION
non-openshift jobs should not be processed by the reconciliation logic

Fixes https://github.com/openshift/jenkins/issues/567