### PR TITLE
Jenkins job run delete delayed

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -22,4 +22,5 @@ public class Annotations {
     public static final String GENERATED_BY = "jenkins.openshift.io/generated-by";
     public static final String GENERATED_BY_JENKINS = "jenkins";
     public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
+    public static final String BUILDCONFIG_NAME = "openshift.io/build-config.name";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -84,7 +84,11 @@ import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_B
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_NAME;
 import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancellable;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isNew;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.updateOpenShiftBuildPhase;
 import static java.util.Collections.sort;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
@@ -479,6 +483,11 @@ public class JenkinsUtils {
 				LOGGER.warning("Unable to delete run " + run.toString() + ":" + e.getMessage());
 			}
 	}
+
+  public synchronized static void deleteRun(WorkflowJob job, Build build) {
+      WorkflowRun run = getRun(job, build);
+      deleteRun(run);
+  }
 
 	private static boolean cancelRunningBuild(WorkflowJob job, Build build) {
 		String buildUid = build.getMetadata().getUid();


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565894

`getJobFromBuildConfigNameNamespace(build.getMetadata().getName(), build.getMetadata().getNamespace())`
was using the build name instead of the buildConfig name, so the innerDeleteEventToJenkinsJobRun seems to not have been called at all from deleteEventToJenkinsJobRun ...
