### PR TITLE
buildConfigPropertyForJob does not loop through all namespaces

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -57,11 +57,11 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 
 	private String skipBranchSuffix;
 
-    private int buildListInterval = 300;
-    private int buildConfigListInterval = 300;
-    private int secretListInterval = 300;
-    private int configMapListInterval = 300;
-    private int imageStreamListInterval = 300;
+  private int buildListInterval = 300;
+  private int buildConfigListInterval = 300;
+  private int secretListInterval = 300;
+  private int configMapListInterval = 300;
+  private int imageStreamListInterval = 300;
     
 	private transient BuildWatcher buildWatcher;
 


### PR DESCRIPTION
The PipelineJobListener takes jobs created in Jenkins that match a specific jobNamePattern
and creates buildConfigs for them in OpenShift.  It also updates the buildConfig in
OpenShift if the job is updated in Jenkins.  It does not seem to do any syncing from
OpenShift -> Jenkins.

PipelineJobListener.buildConfigPropertyForJob was basically just using the first defined
namespace from the GlobalPluginConfiguration.namespaces property by just looping
over the first value, which was confusing.  I have just updated the code to be easier
to read and less confusion.

The other way to accomplish this would be to use client.getNamespace() to use the users
default namespace which also seems like a valid option.  Though this way at least provides
the user a way to configure which namespace the buildConfig should be created in by
chaning the order of the namespaces in the plugin configuration.

Fixes #200