### PR TITLE
Add support for syncing certificate type credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ withCredentials([file(credentialsId: 'namespace-mysecretfile', variable: 'MYFILE
  '''
 }
 ```
+ * For a Jenkins Certificate credential, the secret requires the 'certificate' and 'password' attributes. See the example below:
+
+```bash
+# Create the secret
+oc create secret generic mycert --from-file=certificate=mycert.p12 --from-literal=password=password
+# Add label to mark that it should be synced.
+oc label secret mysecretfile credential.sync.jenkins.openshift.io=true
+```
 
 Development Instructions
 ------------------------

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -43,6 +43,7 @@ public class Constants {
 	public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
 	public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
 	public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
+	public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
 	public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
 	public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
 	public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";


### PR DESCRIPTION
Add sync of Openshift opaque secrets to Jenkins certificate credentials. Based on the work for file credentials https://github.com/openshift/jenkins-sync-plugin/pull/222, it uses the 'certificate' attribute: 

```
oc create secret generic testcert --from-file=certificate=./testcert.p12 --from-literal=password=password
oc label secret testcert credential.sync.jenkins.openshift.io=true
```

PKCS 12 Cert can be generated with the following:

```
keytool -genkey -v -keystore testcert.keystore -alias testcert -keyalg RSA -keysize 2048 -validity 10000
keytool -importkeystore -srckeystore testcert.keystore -destkeystore testcert.p12 -deststoretype PKCS12 -srcalias testcert
```