### PR TITLE
Fixed the issue of duplicate pipeline

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -19,37 +19,38 @@ package io.fabric8.jenkins.openshiftsync;
 /**
  */
 public class Constants {
-	public static final String OPENSHIFT_DEFAULT_NAMESPACE = "default";
+    public static final String OPENSHIFT_DEFAULT_NAMESPACE = "default";
 
-	public static final String OPENSHIFT_ANNOTATIONS_BUILD_NUMBER = "openshift.io/build.number";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI = "openshift.io/jenkins-build-uri";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON = "openshift.io/jenkins-pending-input-actions-json";
+    public static final String OPENSHIFT_ANNOTATIONS_BUILD_NUMBER = "openshift.io/build.number";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BUILD_URI = "openshift.io/jenkins-build-uri";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_LOG_URL = "openshift.io/jenkins-log-url";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_CONSOLE_LOG_URL = "openshift.io/jenkins-console-log-url";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_BLUEOCEAN_LOG_URL = "openshift.io/jenkins-blueocean-log-url";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_PENDING_INPUT_ACTION_JSON = "openshift.io/jenkins-pending-input-actions-json";
 
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
-	public static final String OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE = "openshift.io/jenkins-namespace";
-	public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
-	// see PR https://github.com/openshift/jenkins-sync-plugin/pull/189, there was a issue with having "/"
-	// in a label we construct a watch over, where usual UTF-8 encoding of the label name (which becomes part of 
-	// a query param on the REST invocation) was causing okhttp3 to complain (there is even more history/discussion
-	// in the PR as to issues with fixing).
-	// so we avoid use of "/" for this label
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
+    public static final String OPENSHIFT_ANNOTATIONS_JENKINS_NAMESPACE = "openshift.io/jenkins-namespace";
+    public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
+    public static final String OPENSHIFT_LABELS_BUILD_CONFIG_GIT_REPOSITORY_NAME = "openshift.io/gitRepository";
+    // see PR https://github.com/openshift/jenkins-sync-plugin/pull/189, there was a issue with having "/"
+    // in a label we construct a watch over, where usual UTF-8 encoding of the label name (which becomes part of 
+    // a query param on the REST invocation) was causing okhttp3 to complain (there is even more history/discussion
+    // in the PR as to issues with fixing).
+    // so we avoid use of "/" for this label
     public static final String OPENSHIFT_LABELS_SECRET_CREDENTIAL_SYNC = "credential.sync.jenkins.openshift.io";
     public static final String VALUE_SECRET_SYNC = "true";
 
-	public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
-	public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
-	public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
-	public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
-	public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
-	public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
-	public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
-	public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";
-	public static final String OPENSHIFT_BUILD_STATUS_FIELD = "status";
+    public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
+    public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
+    public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
+    public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
+    public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
+    public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
+    public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
+    public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";
+    public static final String OPENSHIFT_BUILD_STATUS_FIELD = "status";
 	
-	public static final String OPENSHIFT_PROJECT_ENV_VAR_NAME = "PROJECT_NAME";
+    public static final String OPENSHIFT_PROJECT_ENV_VAR_NAME = "PROJECT_NAME";
     public static final String OPENSHIFT_PROJECT_FILE = "/run/secrets/kubernetes.io/serviceaccount/namespace";
 
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -248,10 +248,15 @@ public class PipelineJobListener extends ItemListener {
               a single pipeline for a git repo and this will always return one if exists and nothing if does not exist*/
             if (!jobBuildConfigs.getItems().isEmpty()){
                 jobBuildConfig = jobBuildConfigs.getItems().get(0);
+                logger.info("Able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
+                    " with label gitRepository: " + buildConfigProjectProperty.getName());
             } else {
                 logger.info("Not able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
                     " with label gitRepository: " + buildConfigProjectProperty.getName());
             }
+        } else {
+            logger.info("Able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() + " name: " +
+              buildConfigProjectProperty.getName());
         }
 
         if (jobBuildConfig == null) {
@@ -261,9 +266,6 @@ public class PipelineJobListener extends ItemListener {
                     .addToAnnotations(Annotations.GENERATED_BY, Annotations.GENERATED_BY_JENKINS).endMetadata().withNewSpec().withNewStrategy().withType("JenkinsPipeline").withNewJenkinsPipelineStrategy().endJenkinsPipelineStrategy()
                     .endStrategy().endSpec().build();
         } else {
-
-            logger.info("Able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
-                " with label gitRepository: " + buildConfigProjectProperty.getName());
 
             ObjectMeta metadata = jobBuildConfig.getMetadata();
             String uid = buildConfigProjectProperty.getUid();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -25,26 +25,21 @@ import hudson.model.ItemGroup;
 import hudson.model.listeners.ItemListener;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigBuilder;
-import io.fabric8.openshift.api.model.BuildConfigSpec;
-import io.fabric8.openshift.api.model.BuildSource;
-import io.fabric8.openshift.api.model.BuildStrategy;
-import io.fabric8.openshift.api.model.GitBuildSource;
-import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
+import io.fabric8.openshift.api.model.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.removeJobWithBuildConfig;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMapper.updateBuildConfigFromJob;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_DEFAULT_NAMESPACE;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_GIT_REPOSITORY_NAME;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -220,15 +215,56 @@ public class PipelineJobListener extends ItemListener {
         return null;
     }
 
+  /*Right now, when the buildconfig name is different then git repo name
+  then sync plugin is not able to find buildconfig by repo name while
+  syncing back to openshift after creating a buildconfig with strategy
+  JenkinsPipeline, and create a new buildconfig repo name, To fix this
+  issue, added a label of gitRepository name so it will first try to
+  find the BuildConfig with name of jenkins job, if that is not present
+  that is our case then it will also try to find the buildconfig having
+  label with the name of jenkins job and then if it is not present will
+  create a new BuildConfig*/
+
     private void upsertBuildConfigForJob(WorkflowJob job, BuildConfigProjectProperty buildConfigProjectProperty) {
         boolean create = false;
+        logger.info("Finding BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() + " name: " +
+             buildConfigProjectProperty.getName());
         BuildConfig jobBuildConfig = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(buildConfigProjectProperty.getNamespace()).withName(buildConfigProjectProperty.getName()).get();
+
+
+        if (jobBuildConfig == null){
+
+            logger.info("Not able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() + " name: " +
+                buildConfigProjectProperty.getName());
+
+            logger.info("Finding BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
+                " with label gitRepository: " + buildConfigProjectProperty.getName());
+
+            BuildConfigList jobBuildConfigs = getOpenShiftClient().buildConfigs().
+                inNamespace(buildConfigProjectProperty.getNamespace())
+                .withLabels(Collections.singletonMap(OPENSHIFT_LABELS_BUILD_CONFIG_GIT_REPOSITORY_NAME, buildConfigProjectProperty.getName())).list();
+
+            /*Always choose the first one because launcher(https://github.com/fabric8-launcher/launcher-backend) will create
+              a single pipeline for a git repo and this will always return one if exists and nothing if does not exist*/
+            if (!jobBuildConfigs.getItems().isEmpty()){
+                jobBuildConfig = jobBuildConfigs.getItems().get(0);
+            } else {
+                logger.info("Not able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
+                    " with label gitRepository: " + buildConfigProjectProperty.getName());
+            }
+        }
+
         if (jobBuildConfig == null) {
+
             create = true;
             jobBuildConfig = new BuildConfigBuilder().withNewMetadata().withName(buildConfigProjectProperty.getName()).withNamespace(buildConfigProjectProperty.getNamespace())
                     .addToAnnotations(Annotations.GENERATED_BY, Annotations.GENERATED_BY_JENKINS).endMetadata().withNewSpec().withNewStrategy().withType("JenkinsPipeline").withNewJenkinsPipelineStrategy().endJenkinsPipelineStrategy()
                     .endStrategy().endSpec().build();
         } else {
+
+            logger.info("Able to find BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
+                " with label gitRepository: " + buildConfigProjectProperty.getName());
+
             ObjectMeta metadata = jobBuildConfig.getMetadata();
             String uid = buildConfigProjectProperty.getUid();
             if (metadata != null && StringUtils.isEmpty(uid)) {
@@ -255,6 +291,8 @@ public class PipelineJobListener extends ItemListener {
 
         if (create) {
             try {
+                logger.info("Creating BuildConfig for namespace: " + buildConfigProjectProperty.getNamespace() +
+                    " with name: " + buildConfigProjectProperty.getName());
                 BuildConfig bc = getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(jobBuildConfig.getMetadata().getNamespace()).create(jobBuildConfig);
                 String uid = bc.getMetadata().getUid();
                 buildConfigProjectProperty.setUid(uid);


### PR DESCRIPTION
Right now, when the buildconfig name is different then git repo name
then sync plugin is not able to find buildconfig by repo name while
syncing back to openshift after creating a buildconfig with strategy
JenkinsPipeline, and create a new buildconfig repo name, To fix this
issue, added a label of gitRepository name so it will first try to
find the BuildConfig with name of jenkins job, if that is not present
that is our case then it will also try to find the buildconfig having
label with the name of jenkins job and then if it is not present will
create a new BuildConfig #27

Declared constant variable for label key

Removed NPE and added comments in the code to always know the context behind this

cherry-pick of https://github.com/fabric8io/jenkins-sync-plugin/pull/28 , as well as some space/tab issues

@openshift/sig-developer-experience @piyush1594 fyi/ptal