### PR TITLE
Add support for Secret Text (token) style Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ the Jenkins Credentials Plugin.
     * "kubernetes.io/ssh-auth" map to Jenkins SSH User credentials
     * Opaque/generic secrets where the data has a "username" key and a "password" key map to Jenkins Username / Password credentials
     * Opaque/generic secrets where the data has a "ssh-privatekey" map to Jenkins SSH User credentials
+    * Opaque/generic secrets where the data has a "secrettext" key map to Jenkins Secret Text credentials
 * For a Jenkins Secret File credential, the opaque/generic secret requires the 'filename' attribute. See the example below:
 
 ```bash

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
     public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
     public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
     public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
+    public static final String OPENSHIFT_SECRETS_DATA_SECRET_TEXT = "secrettext";
     public static final String OPENSHIFT_SECRETS_TYPE_SSH = "kubernetes.io/ssh-auth";
     public static final String OPENSHIFT_SECRETS_TYPE_BASICAUTH = "kubernetes.io/basic-auth";
     public static final String OPENSHIFT_SECRETS_TYPE_OPAQUE = "Opaque";

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -311,7 +311,7 @@ public class CredentialsUtils {
             return null;
 
         }
-        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, SecretBytes.fromString(secretText));
+        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, hudson.util.Secret.fromString(secretText));
     }
 
     private static Credentials newCertificateCredential(String secretName, String passwordData, String certificateData) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -19,6 +19,7 @@ import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -257,6 +258,10 @@ public class CredentialsUtils {
             if (isNotBlank(certificateDate)) {
                 return newCertificateCredential(secretName, passwordData, certificateDate);
             }
+            String secretTextData = data.get(OPENSHIFT_SECRETS_DATA_SECRET_TEXT);
+            if (isNotBlank(secretTextData)) {
+                return newSecretTextCredential(secretName, secretTextData);
+            }
 
             logger.log(
                     Level.WARNING,
@@ -293,6 +298,19 @@ public class CredentialsUtils {
 
         }
         return new FileCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, secretName, SecretBytes.fromString(fileData));
+    }
+
+    private static Credentials newSecretTextCredential(String secretName, String secretText) {
+        if (secretName == null || secretName.length() == 0 ||
+                secretText == null || secretText.length() == 0) {
+            logger.log(Level.WARNING, "Invalid secret data, secretName: " +
+                    secretName + " secretText is null: " + (secretText == null) +
+                    " secretText is empty: " +
+                    (secretText != null ? secretText.length() == 0 : false));
+            return null;
+
+        }
+        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, SecretBytes.fromString(secretText));
     }
 
     private static Credentials newCertificateCredential(String secretName, String passwordData, String certificateData) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -265,12 +265,13 @@ public class CredentialsUtils {
 
             logger.log(
                     Level.WARNING,
-                    "Opaque secret {0} either requires {1} and {2} fields for basic auth; {3} field for SSH key; {4} field for file or {5} field for certificate credential",
+                    "Opaque secret {0} either requires {1} and {2} fields for basic auth; {3} field for SSH key; {4} field for file; {5} field for certificate credential or {6} field for secret text",
                     new Object[] { secretName, OPENSHIFT_SECRETS_DATA_USERNAME,
                             OPENSHIFT_SECRETS_DATA_PASSWORD,
                             OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY,
                             OPENSHIFT_SECRETS_DATA_FILENAME,
-                            OPENSHIFT_SECRETS_DATA_CERTIFICATE});
+                            OPENSHIFT_SECRETS_DATA_CERTIFICATE,
+                            OPENSHIFT_SECRETS_DATA_SECRET_TEXT});
             return null;
         case OPENSHIFT_SECRETS_TYPE_BASICAUTH:
             return newUsernamePasswordCredentials(secretName,


### PR DESCRIPTION
I read in PR 49 of jenkinsci/openshift-sync-plugin (https://github.com/jenkinsci/openshift-sync-plugin/pull/49) that feature suggestions should be submitted as a PR here.

This PR would add support for the secret text credentials, also known as string credentials, from the Plain Credentials plugin.

The credential type being supported: https://github.com/jenkinsci/plain-credentials-plugin/blob/master/src/main/java/org/jenkinsci/plugins/plaincredentials/StringCredentials.java