### PR TITLE
decode secrettext

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -311,7 +311,8 @@ public class CredentialsUtils {
             return null;
 
         }
-        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, hudson.util.Secret.fromString(new String(Base64.decode(secretText))));
+        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName,
+            hudson.util.Secret.fromString(new String(Base64.decode(secretText), StandardCharsets.UTF_8)));
     }
 
     private static Credentials newCertificateCredential(String secretName, String passwordData, String certificateData) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -311,7 +311,7 @@ public class CredentialsUtils {
             return null;
 
         }
-        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, hudson.util.Secret.fromString(secretText));
+        return new StringCredentialsImpl(CredentialsScope.GLOBAL, secretName, secretName, hudson.util.Secret.fromString(new String(Base64.decode(secretText))));
     }
 
     private static Credentials newCertificateCredential(String secretName, String passwordData, String certificateData) {


### PR DESCRIPTION
I noticed when syncing secrettext to Jenkins the base64 encoded value is being passed as the credential.