### PR TITLE
Fix env vars from JenkinsPipelineBuildStrategy could be null values

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -204,7 +204,8 @@ public class JenkinsUtils {
 			// build list of env var keys for compare with existing job params
 			for (EnvVar env : envs) {
 				envKeys.add(env.getName());
-				envVarList.add(new StringParameterValue(env.getName(), env.getValue()));
+        // Convert null value to empty string.
+        envVarList.add(new StringParameterValue(env.getName(), env.getValue() != null ? env.getValue() : ""));
 			}
 		}
 
@@ -287,7 +288,8 @@ public class JenkinsUtils {
 		if (envs.size() > 0) {
 			// build list of env var keys for compare with existing job params
 			for (EnvVar env : envs) {
-				envVarList.add(new StringParameterValue(env.getName(), env.getValue()));
+        // Convert null value to empty string.
+        envVarList.add(new StringParameterValue(env.getName(), env.getValue() != null ? env.getValue() : ""));
 			}
 		}
 
@@ -585,12 +587,12 @@ public class JenkinsUtils {
 			return null;
 		}
 
-		WorkflowJob job = BuildConfigToJobMap.getJobFromBuildConfigNameNamespace(buildConfigName, 
+		WorkflowJob job = BuildConfigToJobMap.getJobFromBuildConfigNameNamespace(buildConfigName,
 		        build.getMetadata().getNamespace());
 		if (job != null) {
 		    return job;
 		}
-		
+
 		BuildConfig buildConfig = getAuthenticatedOpenShiftClient().buildConfigs()
 				.inNamespace(build.getMetadata().getNamespace()).withName(buildConfigName).get();
 		if (buildConfig == null) {


### PR DESCRIPTION
When start a JenkinsPipelineBuildStrategy with `oc start-build`, if
there is an environment variable with an empty string value, the
corresponding parameter will be set to null value. This could lead to
exceptions.

This PR fixes this issue by replacing null values with empty strings
when passing environment variables from JenkinsPipelineBuildStrategy to
ParametersAction.

Reproduction:
Create a BuildConfig on OpenShift with JenkinsPipelineBuildStrategy, define some environment variables with empty string:
```yaml
kind: "BuildConfig"
apiVersion: "v1"
metadata:
  name: "demo-pipeline"
spec:
  strategy:
    jenkinsPipelineStrategy:
      env:
      - name: "NAME"
        value: ""
      jenkinsfile: |-
        pipeline {
          agent {
            kubernetes {
              cloud 'openshift'
              label "jenkins-slave-${UUID.randomUUID().toString()}"
              yaml """
              apiVersion: v1
              kind: Pod
              metadata:
                labels:
                  app: "my-jenkins-slave"
              spec:
                containers:
                - name: jnlp
                  image: docker.io/openshift/jenkins-slave-base-centos7:latest
                  tty: true
                  resources:
                    requests:
                      memory: 512Mi
                      cpu: 200m
                    limits:
                      memory: 768Mi
                      cpu: 500m
              """
            }
          }
          stages {
            stage('foo') {
              steps {
                echo "Hello, ${env.NAME}"
              }
            }
          }
        }
```
Then start a build with `oc start-build demo-pipeline` or `oc start-build demo-pipeline -e NAME=`. You will get an error message from the Jenkins Console output like this:
```
java.lang.IllegalArgumentException: Null value not allowed as an environment variable: NAME
	at hudson.EnvVars.put(EnvVars.java:359)
	at hudson.model.StringParameterValue.buildEnvironment(StringParameterValue.java:59)
	at hudson.model.ParametersAction.buildEnvironment(ParametersAction.java:145)
	at hudson.model.Run.getEnvironment(Run.java:2294)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getEnvironment(WorkflowRun.java:513)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerStepExecution.start(ContainerStepExecution.java:86)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:229)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:153)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesDeclarativeAgentScript.run(jar:file:/var/lib/jenkins/plugins/kubernetes/WEB-INF/lib/kubernetes.jar!/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy:58)
	at org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript.checkoutAndRun(jar:file:/var/lib/jenkins/plugins/pipeline-model-extensions/WEB-INF/lib/pipeline-model-extensions.jar!/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy:66)
	at org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript.doCheckout(jar:file:/var/lib/jenkins/plugins/pipeline-model-extensions/WEB-INF/lib/pipeline-model-extensions.jar!/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy:42)
	at org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesDeclarativeAgentScript.run(jar:file:/var/lib/jenkins/plugins/kubernetes/WEB-INF/lib/kubernetes.jar!/org/csanchez/jenkins/plugins/kubernetes/pipeline/KubernetesDeclarativeAgentScript.groovy:48)
	at ___cps.transform___(Native Method)
	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:57)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:109)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:82)
	at sun.reflect.GeneratedMethodAccessor302.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
	at com.cloudbees.groovy.cps.impl.ClosureBlock.eval(ClosureBlock.java:46)
	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:122)
	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:261)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$101(SandboxContinuable.java:34)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.lambda$run0$0(SandboxContinuable.java:59)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:58)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:174)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:332)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$200(CpsThreadGroup.java:83)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:244)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:232)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:64)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:131)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```
