### PR TITLE
Additional fix of the null parameter issue

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -175,7 +175,7 @@ public class JenkinsUtils {
 			}
 			for (EnvVar env : envs) {
 				if (replaceExisting) {
-					StringParameterDefinition envVar = new StringParameterDefinition(env.getName(), env.getValue(),
+					StringParameterDefinition envVar = new StringParameterDefinition(env.getName(), env.getValue() != null ? env.getValue() : "",
 							PARAM_FROM_ENV_DESCRIPTION);
 					paramMap.put(env.getName(), envVar);
 				} else if (!paramMap.containsKey(env.getName())) {


### PR DESCRIPTION
Following up #250 and [Bug 1614695](https://bugzilla.redhat.com/show_bug.cgi?id=1614695),
the null string value should also be replaced with empty string when
creating a Jenkins job, otherwise a job run triggered by timer or
pollSCM triggers will also fail with NullPointerException.