### PR TITLE
add link to env->param mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ Restrictions
 The "child" Pipeline Strategy builds will start, but the status cannot be properly captured and the "parent" Pipeline Strategy build fails.
 * Do not run multiple jenkins instances running the sync plugin and monitoring the same namespace(s).  There is no coordination between multiple instances of this plugin monitoring the same namespace.  Unpredictable results, such as duplicate, concurrent attempts at initiating OpenShift Pipeline Strategy Builds or initiating Jenkins Job runs that correspond to OpenShift Pipeline Strategy Builds, can result.
 
+Build Config Environment Variable to Jenkins Job Parameter Mapping
+------------------------------------------------------------------
+
+See [the OKD documentation](https://docs.okd.io/latest/dev_guide/builds/build_strategies.html#jenkins-pipeline-strategy-environment) for details.
+


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-sync-plugin/issues/302 along with https://github.com/openshift/openshift-docs/pull/14558

Trying to inject dynamic env var / job params can suffer from jenkins fragility when it is under stress