### PR TITLE
Secret Text is not encoded when it is passed to newSecretTextCredential.

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -231,7 +231,7 @@ public class CredentialsUtils {
 
             return null;
         }
-        return newSecretTextCredential(secretName, text);
+        return newSecretTextCredential(secretName, new String(Base64.encode(text.getBytes())));
     }
 
     private static Credentials secretToCredentials(Secret secret) {


### PR DESCRIPTION
fixes issue https://github.com/openshift/jenkins-sync-plugin/issues/293

No secret created. 

cc @gabemontero 