### PR TITLE
CVE-2019-12384 : FasterXML jackson-databind 2.x before 2.9.9.1 might …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,13 +333,13 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.6</version>
+        <version>2.9.9</version>
     </dependency>
 
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.6</version>
+        <version>2.9.9.2</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
…allow attackers to have a variety of impacts by leveraging failure to block the logback-core class from polymorphic deserialization