### PR TITLE
Feature/disablepruning : Disable Jenkins Job Pruning via Annotation

### DIFF
--- a/PR-Testing/e2e-test-jenkins-migration.sh
+++ b/PR-Testing/e2e-test-jenkins-migration.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+wait-for-build () {
+    local build_name=$1
+    while true; do
+        echo "Waiting for ${build_name} to complete"
+        status=$( oc get build "${build_name}" -o jsonpath='{ .status.phase }' )
+        if [[ "${status}" == "New" ||  "${status}" == "Pending" ||  "${status}" == "Running" ]]; then
+            sleep 3
+        fi
+        if [[  "${status}" == "Complete" ]]; then
+            return 0
+        fi
+        if [[  "${status}" == "Failed" ||  "${status}" == "Error" ||  "${status}" == "Cancelled" ]]; then
+            return 1
+        fi
+    done
+}
+
+
+NAMESPACE=$1
+oc project $NAMESPACE || oc new-project $NAMESPACE
+oc new-app jenkins-persistent
+
+SRC_PIPELINE=nodejs-ex-pipeline
+DST_PIPELINE=nodejs-ex-pipeline-2
+GIT_REPO=https://github.com/waveywaves/nodejs-ex
+GIT_CONTEXT=openshift/pipelines
+JENKINS_BASE_DIR_PREFIX=/var/lib/jenkins/jobs/$NAMESPACE/jobs/${NAMESPACE}
+
+
+# Waiting for jenkins deployment to be ready
+echo "Waiting for jenkins deployment to be ready"
+oc rollout status deploymentconfig jenkins --watch
+
+oc new-app $GIT_REPO  --context-dir=$GIT_CONTEXT --name $SRC_PIPELINE
+oc patch  bc $SRC_PIPELINE -p '{ "spec" : { "runPolicy" : "Parallel" }}'
+
+
+# Create 4 others builds in parallel
+oc start-build $SRC_PIPELINE &
+oc start-build $SRC_PIPELINE &
+oc start-build $SRC_PIPELINE &
+oc start-build $SRC_PIPELINE &
+oc start-build $SRC_PIPELINE &
+
+# Create the destination pipeline for migration, delete the auto-started build and annotate it
+oc new-app $GIT_REPO  --context-dir=$GIT_CONTEXT --name $DST_PIPELINE
+oc delete build "${DST_PIPELINE}"-1
+oc annotate bc $DST_PIPELINE jenkins.openshift.io/disable-job-prune=true
+
+
+wait-for-build ${SRC_PIPELINE}-5
+
+JENKINS_POD=$(oc get pods --no-headers --selector=name=jenkins | cut -f1 -d\  )
+echo "Must execute this in pod $JENKINS_POD"
+echo "cp -fr $JENKINS_BASE_DIR_PREFIX-${SRC_PIPELINE}/builds/ $JENKINS_BASE_DIR_PREFIX-${DST_PIPELINE}/builds/"
+oc exec $JENKINS_POD -- cp -fr $JENKINS_BASE_DIR_PREFIX-${SRC_PIPELINE}/builds/ $JENKINS_BASE_DIR_PREFIX-${DST_PIPELINE}/
+oc get --export builds --selector=buildconfig=$SRC_PIPELINE -o yaml | sed s/$SRC_PIPELINE/$DST_PIPELINE/g | oc create -f -
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -9,19 +9,20 @@ The synchronization works like this
 the Jenkins Credentials Plugin.
 * Creating a new OpenShift Build for a BuildConfig associated with a Jenkins Job results in the Jenkins Job being triggered
 * Changes in a Jenkins Build Run thats associated with a Jenkins Job gets replicated to an OpenShift Build object (which is created if necessary if the build was triggered via Jenkins)
+* Annotating a BuildConfig with `jenkins.openshift.io/disable-job-prune` set to `true` allows for all Jenkins Jobs corresponding to Builds spawned using the BuildConfig, to not be pruned upon deletion of the Builds themselves. This is helpful during migration of Jobs from one volume to another.
 * Changes in OpenShift ConfigMap resources are examined for XML documents that correspond to Pod Template configuration for the Kubernetes Cloud plugin at http://github.com/jenkinsci/kubernetes-plugin and change the configuration of the Kubernetes Cloud plugin running in Jenkins to add, edit, or remove Pod Templates based on what exists in the ConfigMap; also note, if the <image></image> setting of the Pod Template starts with "imagestreamtag:", then this plugin will look up the ImageStreamTag for that entry (stripping "imagestreamtag:" first) and if found, replace the entry with the ImageStreamTag's Docker image reference.
     * Note, if both a ConfigMap and Imagestream attempt to create a PodTemplate of the same name, the first watch event to arrive at the sync plugin claims ownership of the PodTemplate with the given name until the object is deleted or the label is removed.  The other object's PodTemplate definition is ignored until the other object is deleted/label removed and a new event / relist occurs for the other object.
-* Changes to OpenShift ImageStream resources with the label "role" set to "jenkins-slave" and ImageStreamTag resources with the annotation "role" set to "jenkins-slave" are considered images to be used as Pod Templates for the Kubernetes Cloud plugin, where the Pod Templates are added, modified, or deleted from the Kubernetes cloud plugin as corresponding ImageStreams and ImageStreamTags are added, modified, or deleted, or have the "role=jenkins-slave" setting changed.  Also, while you cannot set a label directly on an ImageStreamTag, they inherit any labels set on the parent ImageStream.  This plugin will now detect that as well, and create PodTemplates for each ImageStreamTag in addition to the ImageStream.  Also note, the ImageStream's `dockerImageRepository` field is used for the image setting for its PodTemplate.  By comparison, the `dockerImageReference` of each ImageStreamTag is used for the image setting of the corresponding PodTemplate.
+* Changes to OpenShift ImageStream resources with the label "role" set to "jenkins-slave" and ImageStreamTag resources with the annotation `role` set to `jenkins-slave` are considered images to be used as Pod Templates for the Kubernetes Cloud plugin, where the Pod Templates are added, modified, or deleted from the Kubernetes cloud plugin as corresponding ImageStreams and ImageStreamTags are added, modified, or deleted, or have the "role=jenkins-slave" setting changed.  Also, while you cannot set a label directly on an ImageStreamTag, they inherit any labels set on the parent ImageStream.  This plugin will now detect that as well, and create PodTemplates for each ImageStreamTag in addition to the ImageStream.  Also note, the ImageStream's `dockerImageRepository` field is used for the image setting for its PodTemplate.  By comparison, the `dockerImageReference` of each ImageStreamTag is used for the image setting of the corresponding PodTemplate.
     * Note, if both a ConfigMap and Imagestream attempt to create a PodTemplate of the same name, the first watch event to arrive at the sync plugin claims ownership of the PodTemplate with the given name until the object is deleted or the label is removed.  The other object's PodTemplate definition is ignored until the other object is deleted/label removed and a new event / relist occurs for the other object.
-* Changes to OpenShift Secrets with the label "credential.sync.jenkins.openshift.io" set to "true" will result in those Secrets getting converted into Jenkins Credentials that are registered with the Jenkins Credentials Plugin.  Mappings occur as follows:
-    * First, the name.  By default, the name of the credential in Jenkins will be "<namespace the secret comes from>-<name of the secret>".  But you can use the annotation "jenkins.openshift.io/secret.name" to control what name is used for the Jenkins credential.  However, any naming conflicts are not handled by this plugin.  Now, the mappings:
-    * "kubernetes.io/basic-auth" map to Jenkins Username / Password credentials
-    * "kubernetes.io/ssh-auth" map to Jenkins SSH User credentials
-    * Opaque/generic secrets where the data has a "username" key and a "password" key map to Jenkins Username / Password credentials
-    * Opaque/generic secrets where the data has a "ssh-privatekey" map to Jenkins SSH User credentials
-    * Opaque/generic secrets where the data has a "secrettext" key map to Jenkins Secret Text credentials
-    * Opaque/generic secrets where the data has a "openshift-client-token" key map to Jenkins OpenShift Client Plugin Token credentials
-* For a Jenkins Secret File credential, the opaque/generic secret requires the 'filename' attribute. See the example below:
+* Changes to OpenShift Secrets with the label `credential.sync.jenkins.openshift.io` set to `true` will result in those Secrets getting converted into Jenkins Credentials that are registered with the Jenkins Credentials Plugin.  Mappings occur as follows:
+    * First, the name.  By default, the name of the credential in Jenkins will be "<namespace the secret comes from>-<name of the secret>".  But you can use the annotation `jenkins.openshift.io/secret.name` to control what name is used for the Jenkins credential.  However, any naming conflicts are not handled by this plugin.  Now, the mappings:
+    * `kubernetes.io/basic-auth` map to Jenkins Username / Password credentials
+    * `kubernetes.io/ssh-auth` map to Jenkins SSH User credentials
+    * Opaque/generic secrets where the data has a `username` key and a `password` key map to Jenkins Username / Password credentials
+    * Opaque/generic secrets where the data has a `ssh-privatekey` map to Jenkins SSH User credentials
+    * Opaque/generic secrets where the data has a `secrettext` key map to Jenkins Secret Text credentials
+    * Opaque/generic secrets where the data has a `openshift-client-token` key map to Jenkins OpenShift Client Plugin Token credentials
+* For a Jenkins Secret File credential, the opaque/generic secret requires the `filename` attribute. See the example below:
 
 ```bash
 # Create the secret
@@ -39,7 +40,7 @@ withCredentials([file(credentialsId: 'namespace-mysecretfile', variable: 'MYFILE
  '''
 }
 ```
-* For a Jenkins Certificate credential, the opaque/generic secret requires the 'certificate' and 'password' attributes. See the example below:
+* For a Jenkins Certificate credential, the opaque/generic secret requires the `certificate` and `password` attributes. See the example below:
 
 ```bash
 # Create the secret

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -24,4 +24,5 @@ public class Annotations {
     public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
     public static final String BUILDCONFIG_NAME = "openshift.io/build-config.name";
     public static final String SECRET_NAME = "jenkins.openshift.io/secret.name";
+    public static final String DISABLE_JOB_PRUNING= "jenkins.openshift.io/disable-job-prune";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
@@ -103,6 +103,11 @@ public class BuildCause extends Cause {
         return uid;
     }
 
+    public void setUid(String newUid) {
+      this.uid = newUid;
+      uid = newUid;
+    }
+
     public String getNamespace() {
         return namespace;
     }
@@ -121,6 +126,11 @@ public class BuildCause extends Cause {
 
     public String getBuildConfigUid() {
         return buildConfigUid;
+    }
+
+    public void setBuildConfigUid(String newBuildConfigUid) {
+      this.buildConfigUid = newBuildConfigUid;
+      buildConfigUid = newBuildConfigUid;
     }
 
     public int getNumStages() {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
@@ -91,8 +91,7 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
                     }
                 }
                 if (cause != null && ret != null)
-                    BuildToActionMapper.addCauseAction(ret.getMetadata()
-                            .getName(), cause);
+                    BuildToActionMapper.addCauseAction(ret.getMetadata().getName(), cause);
 
                 return false;
             }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -209,7 +209,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
         }
 
         RunExt wfRunExt = RunExt.create((WorkflowRun) run);
-
+        String displayName = run.getDisplayName();
         // try blue run
         BlueRun blueRun = null;
         try {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -553,6 +553,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
                 return BuildPhases.RUNNING;
             } else {
                 Result result = run.getResult();
+                // TODO replace with switch case
                 if (result != null) {
                     if (result.equals(Result.SUCCESS)) {
                         return BuildPhases.COMPLETE;

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -26,9 +26,7 @@ import io.fabric8.openshift.api.model.BuildList;
 import io.fabric8.openshift.api.model.BuildStatus;
 import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
-
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
@@ -50,8 +48,18 @@ import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBui
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_BUILD_NUMBER;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
-import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.*;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.cancelBuild;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.deleteRun;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.deleteRunIfPruneEnabled;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.getJobFromBuild;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.handleBuildList;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.triggerJob;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAnnotation;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancellable;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isNew;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.updateOpenShiftBuildPhase;
 import static java.util.logging.Level.WARNING;
 
 public class BuildWatcher extends BaseWatcher {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -18,7 +18,6 @@ package io.fabric8.jenkins.openshiftsync;
 import com.cloudbees.plugins.credentials.CredentialsParameterDefinition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
-import hudson.model.Queue;
 import hudson.model.Action;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.Cause;
@@ -31,6 +30,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PasswordParameterDefinition;
+import hudson.model.Queue;
 import hudson.model.RunParameterDefinition;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
@@ -92,8 +92,6 @@ import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_
 import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isJobPruningDisabled;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobFullName;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.updateOpenShiftBuildPhase;
 import static java.util.Collections.sort;
 import static java.util.logging.Level.SEVERE;
@@ -537,10 +535,8 @@ public class JenkinsUtils {
 	}
 
   public static void deleteRunIfPruneEnabled(WorkflowRun run, BuildConfigProjectProperty buildConfigProjectProperty){
-      BuildCause cause = run.getCause(BuildCause.class);
-      if (isJobPruningDisabled(buildConfigProjectProperty) || cause.getUid().contains(DISABLE_PRUNE_PREFIX)) {
-        BuildConfig buildConfig = buildConfigProjectProperty.getBuildConfig();
-        LOGGER.info("Prune disabled on Jenkins Job " + jenkinsJobFullName(buildConfig));
+      if (buildConfigProjectProperty.getUid().startsWith(DISABLE_PRUNE_PREFIX)) {
+        LOGGER.info("Prune disabled on Jenkins Job on BuildConfig" + buildConfigProjectProperty.getName() + "in Namespace "+buildConfigProjectProperty.getNamespace());
       } else {
         deleteRun(run);
       }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -536,7 +536,7 @@ public class JenkinsUtils {
 
   public static void deleteRunIfPruneEnabled(WorkflowRun run, BuildConfigProjectProperty buildConfigProjectProperty){
       if (buildConfigProjectProperty.getUid().startsWith(DISABLE_PRUNE_PREFIX)) {
-        LOGGER.info("Prune disabled on Jenkins Job on BuildConfig" + buildConfigProjectProperty.getName() + "in Namespace "+buildConfigProjectProperty.getNamespace());
+        LOGGER.info("Prune disabled on Jenkins Job on BuildConfig " + buildConfigProjectProperty.getName() + " in Namespace "+buildConfigProjectProperty.getNamespace());
       } else {
         deleteRun(run);
       }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -15,54 +15,10 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
-import static io.fabric8.jenkins.openshiftsync.Annotations.DISABLE_JOB_PRUNING;
-import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfig;
-import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.putJobWithBuildConfig;
-import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
-import static io.fabric8.jenkins.openshiftsync.BuildPhases.PENDING;
-import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL;
-import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL_LATEST_ONLY;
-import static io.fabric8.jenkins.openshiftsync.BuildWatcher.addEventToJenkinsJobRun;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_BUILD_NUMBER;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
-import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_NAME;
-import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.*;
-import static java.util.Collections.sort;
-import static java.util.logging.Level.SEVERE;
-import static java.util.logging.Level.WARNING;
-import static org.apache.commons.lang.StringUtils.isBlank;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.tools.ant.filters.StringInputStream;
-import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
-import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
-import org.csanchez.jenkins.plugins.kubernetes.PodVolumes;
-import org.eclipse.jgit.transport.URIish;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-
 import com.cloudbees.plugins.credentials.CredentialsParameterDefinition;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
+import hudson.model.Queue;
 import hudson.model.Action;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.Cause;
@@ -75,7 +31,6 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PasswordParameterDefinition;
-import hudson.model.Queue;
 import hudson.model.RunParameterDefinition;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
@@ -99,6 +54,51 @@ import io.fabric8.openshift.api.model.SourceRevision;
 import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 import jenkins.util.Timer;
+import org.apache.commons.lang.StringUtils;
+import org.apache.tools.ant.filters.StringInputStream;
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
+import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
+import org.csanchez.jenkins.plugins.kubernetes.PodVolumes;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfig;
+import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.putJobWithBuildConfig;
+import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
+import static io.fabric8.jenkins.openshiftsync.BuildPhases.PENDING;
+import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL;
+import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL_LATEST_ONLY;
+import static io.fabric8.jenkins.openshiftsync.BuildWatcher.addEventToJenkinsJobRun;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_BUILD_NUMBER;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_BUILD_STATUS_FIELD;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_NAME;
+import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isJobPruningDisabled;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobFullName;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.updateOpenShiftBuildPhase;
+import static java.util.Collections.sort;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
  */

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JobProcessor.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JobProcessor.java
@@ -122,8 +122,6 @@ public class JobProcessor extends NotReallyRoleSensitiveCallable<Void, Exception
 
     String oldUID = UID.replace(DISABLE_PRUNE_PREFIX,"");
     String oldName = buildConfigProjectProperty.getNamespace() + "/" + buildConfigProjectProperty.getNamespace() + "-" + buildConfigProjectProperty.getName();
-    System.out.println("-------------- Comparing names "+jenkinsJobFullName(buildConfig)+"------------ "+oldName);
-    System.out.println("-------------- BuildConfigUID updated from -------"+UID+"--------"+oldUID+"--------"+newUID);
 
     if (UID.startsWith(DISABLE_PRUNE_PREFIX) && !oldUID.equals(newUID) && oldName.equals(jenkinsJobFullName(buildConfig))){
       logger.info("Migrating WorkflowJob "+jenkinsJobFullName(buildConfig));

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -68,11 +68,15 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.fabric8.jenkins.openshiftsync.Annotations.DISABLE_JOB_PRUNING;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.NEW;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.PENDING;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.RUNNING;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_DEFAULT_NAMESPACE;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.getBuildConfigName;
 import static java.util.logging.Level.FINE;
+
+import static  io.fabric8.jenkins.openshiftsync.JenkinsUtils.DISABLE_PRUNE_PREFIX;
 
 /**
  */
@@ -656,6 +660,19 @@ public class OpenShiftUtils {
         }
         return null;
     }
+
+    public static boolean isJobPruningDisabled(BuildConfigProjectProperty buildConfigProjectProperty){
+        BuildConfig buildConfig = buildConfigProjectProperty.getBuildConfig();
+        if (buildConfig != null){
+          String UID = buildConfigProjectProperty.getUid();
+          String disableJobPruning = getAnnotation(buildConfig, DISABLE_JOB_PRUNING);
+          if ((disableJobPruning != null && disableJobPruning.length() > 0) || UID.contains(DISABLE_PRUNE_PREFIX) ) {
+            return true;
+          }
+        }
+        return false;
+    }
+
 
     abstract class StatelessReplicationControllerMixIn extends
             ReplicationController {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -505,10 +505,14 @@ public class OpenShiftUtils {
         logger.log(FINE, "setting build to {0} in namespace {1}/{2}",
                 new Object[] { phase, build.getMetadata().getNamespace(),
                         build.getMetadata().getName() });
-        getAuthenticatedOpenShiftClient().builds()
-                .inNamespace(build.getMetadata().getNamespace())
-                .withName(build.getMetadata().getName()).edit().editStatus()
-                .withPhase(phase).endStatus().done();
+
+        BuildStatus currentStatus = build.getStatus();
+        if (isNew(currentStatus) || isRunning(currentStatus) || isPending(currentStatus) ){
+          getAuthenticatedOpenShiftClient().builds()
+            .inNamespace(build.getMetadata().getNamespace())
+            .withName(build.getMetadata().getName()).edit().editStatus()
+            .withPhase(phase).endStatus().done();
+        }
     }
 
     /**
@@ -581,6 +585,14 @@ public class OpenShiftUtils {
 
     public static boolean isNew(BuildStatus buildStatus) {
         return buildStatus.getPhase().equals(NEW);
+    }
+
+    public static boolean isRunning(BuildStatus buildStatus) {
+      return buildStatus.getPhase().equals(RUNNING);
+    }
+
+    public static boolean isPending(BuildStatus buildStatus) {
+      return buildStatus.getPhase().equals(PENDING);
     }
 
     public static boolean isCancelled(BuildStatus status) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -20,10 +20,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
-import hudson.model.ItemGroup;
 import hudson.BulkChange;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.util.XStream2;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -46,7 +45,6 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import jenkins.model.Jenkins;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.joda.time.DateTime;
@@ -73,10 +71,8 @@ import static io.fabric8.jenkins.openshiftsync.BuildPhases.NEW;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.PENDING;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.RUNNING;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_DEFAULT_NAMESPACE;
-import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.getBuildConfigName;
+import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.DISABLE_PRUNE_PREFIX;
 import static java.util.logging.Level.FINE;
-
-import static  io.fabric8.jenkins.openshiftsync.JenkinsUtils.DISABLE_PRUNE_PREFIX;
 
 /**
  */
@@ -666,7 +662,7 @@ public class OpenShiftUtils {
         if (buildConfig != null){
           String UID = buildConfigProjectProperty.getUid();
           String disableJobPruning = getAnnotation(buildConfig, DISABLE_JOB_PRUNING);
-          if ((disableJobPruning != null && disableJobPruning.length() > 0) || UID.contains(DISABLE_PRUNE_PREFIX) ) {
+          if ((disableJobPruning != null && disableJobPruning.length() > 0) || UID.startsWith(DISABLE_PRUNE_PREFIX) ) {
             return true;
           }
         }


### PR DESCRIPTION
### Description

This feature allows the user to disable job pruning in jenkins if they annotate their buildconfig with `jenkins.openshift.io/disable-job-prune=true` as follows 
```
$ oc annotate bc nodejs-ex jenkins.openshift.io/disable-job-prune=true
```
Where nodejs-ex is being watched by the jenkins-sync-plugin.

wrt https://github.com/openshift/jenkins-sync-plugin/issues/312

### Acceptance Criteria

- [x] Add Annotation
- [x] Write the logic for disabling pruning
- [x] Update README

0 > 
![Screenshot from 2019-08-16 20-24-23](https://user-images.githubusercontent.com/11972233/63176672-fbc81580-c063-11e9-81ba-fb6fbbb7d53f.png)

![Screenshot from 2019-08-16 20-26-41](https://user-images.githubusercontent.com/11972233/63176784-32059500-c064-11e9-9812-6e3cca4d540b.png)

1 > Annotating the BuildConfig :-
`oc annotate bc nodejs-ex jenkins.openshift.io/disable-job-prune=true`

2 > Deleting Build: 
`oc delete build nodejs-ex-27`
```
INFO: Reconciling job runs and builds
Aug 16, 2019 2:56:13 PM io.fabric8.jenkins.openshiftsync.BuildWatcher reconcileRunsAndBuilds
INFO: Checking job org.jenkinsci.plugins.workflow.job.WorkflowJob@30553b6a[jenkins-sync-test/jenkins-sync-test-nodejs-ex] runs for BuildConfig jenkins-sync-test/nodejs-ex                                        
Aug 16, 2019 2:56:13 PM io.fabric8.jenkins.openshiftsync.JobProcessor createOrUpdateJob
INFO: Updated job jenkins-sync-test-nodejs-ex from BuildConfig NamespaceName{jenkins-sync-test:nodejs-ex} with revision: 413390                                                                                   
Aug 16, 2019 2:58:04 PM io.fabric8.jenkins.openshiftsync.JenkinsUtils deleteRunIfPruneDisabled
INFO: Prune disabled on Jenkins Job jenkins-sync-test/jenkins-sync-test-nodejs-ex
``` 
![Screenshot from 2019-08-16 20-41-51](https://user-images.githubusercontent.com/11972233/63177828-5c585200-c066-11e9-982e-9ccf4a922050.png)

![Screenshot from 2019-08-16 20-43-06](https://user-images.githubusercontent.com/11972233/63177881-78f48a00-c066-11e9-8332-5ddcf1b9a1a5.png)
