### PR TITLE
Update BuildToActionMapper as it wasn't being updated

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
@@ -80,7 +80,7 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
                     LOGGER.fine("ParametersAction: " + params.toString());
                 }
                 if (params != null && ret != null)
-                    BuildToActionMapper.addParameterAction(ret.getMetadata()
+                    BuildToActionMap.addParameterAction(ret.getMetadata()
                             .getName(), params);
 
                 CauseAction cause = dumpCause(actions);
@@ -91,7 +91,7 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
                     }
                 }
                 if (cause != null && ret != null)
-                    BuildToActionMapper.addCauseAction(ret.getMetadata()
+                    BuildToActionMap.addCauseAction(ret.getMetadata()
                             .getName(), cause);
 
                 return false;

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToActionMap.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToActionMap.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.jenkins.openshiftsync;
+
+import hudson.model.CauseAction;
+import hudson.model.ParametersAction;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BuildToActionMap {
+
+    private static Map<String, ParametersAction> buildToParametersMap;
+    private static Map<String, CauseAction> buildToCauseMap;
+
+    private BuildToActionMap() {
+    }
+
+    static synchronized void initialize() {
+        if (buildToParametersMap == null) {
+            buildToParametersMap = new ConcurrentHashMap<String, ParametersAction>();
+        }
+        if (buildToCauseMap == null) {
+            buildToCauseMap = new ConcurrentHashMap<String, CauseAction>();
+        }
+    }
+
+    static synchronized void addParameterAction(String buildId,
+            ParametersAction params) {
+        buildToParametersMap.put(buildId, params);
+    }
+
+    static synchronized ParametersAction removeParameterAction(String buildId) {
+        return buildToParametersMap.remove(buildId);
+    }
+
+    static synchronized void addCauseAction(String buildId, CauseAction cause) {
+        buildToCauseMap.put(buildId, cause);
+    }
+
+    static synchronized CauseAction removeCauseAction(String buildId) {
+        return buildToCauseMap.remove(buildId);
+    }
+
+}

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -151,7 +151,7 @@ public class BuildWatcher extends BaseWatcher {
     }
 
     public void start() {
-        BuildToActionMapper.initialize();
+        BuildToActionMap.initialize();
         super.start();
     }
 


### PR DESCRIPTION
CauseAction is removed here https://github.com/openshift/jenkins-sync-plugin/blob/master/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java#L414 but never added back again to the Map. Came across this as I was trying to get the CauseAction for particular builds.

Other: This class (BuildToActionMapper) needs to be changed to BuildToActionMap and there needs to be another class (BuildToActionMapper) which maintains a cache of all the existing builds. Similar to BuildConfigToJobMap and BuildConfigToJobMapper 

wrt https://github.com/openshift/jenkins-sync-plugin/issues/332

cc @gabemontero @akram 