### PR TITLE
Bug 1755812: Refactor and allow for updating configmaps to sync PodTemplates dynamically

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BaseWatcher.java
@@ -16,10 +16,13 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import static java.net.HttpURLConnection.HTTP_GONE;
+
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +30,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -115,39 +119,26 @@ public abstract class BaseWatcher {
                     && map.get("role").equals("jenkins-slave");
         return false;
     }
-    
+
     protected boolean isReservedPodTemplateName(String name) {
         if (name.equals("maven") || name.equals("nodejs"))
             return true;
         return false;
     }
-    
+
     protected void processSlavesForAddEvent(List<PodTemplate> slaves, String type, String uid, String apiObjName, String namespace) {
-        List<PodTemplate> finalSlaveList = new ArrayList<PodTemplate>();
+      LOGGER.info("Adding PodTemplate(s) for ");
+      List<PodTemplate> finalSlaveList = new ArrayList<PodTemplate>();
         for (PodTemplate podTemplate : slaves) {
-            String name = podTemplate.getName();
-            // we allow configmap overrides of maven and nodejs, but not imagestream ones
-            // as they are less specific/defined wrt podTemplate fields
-            if (isReservedPodTemplateName(name) && isType.equals(type))
-                continue;
-            // once a CM or IS claims a name, it gets to keep it until it is remove or un-labeled
-            String ret = podTemplateToApiType.putIfAbsent(name, type);
-            // if not set, or previously set by an obj of the same type
-            if (ret == null || ret.equals(type)) {
-                JenkinsUtils.addPodTemplate(podTemplate);
-                finalSlaveList.add(podTemplate);
-            } else {
-                LOGGER.info(String.format(PT_NAME_CLAIMED, type, apiObjName, namespace, name, ret));
-            }
+          addPodTemplate(type, apiObjName, namespace, finalSlaveList, podTemplate);
         }
-        if (finalSlaveList.size() > 0)
-            trackedPodTemplates.put(uid, finalSlaveList);
+        updateTrackedPodTemplatesMap(uid, finalSlaveList);
     }
 
     protected void processSlavesForModifyEvent(List<PodTemplate> slaves, String type, String uid, String apiObjName, String namespace) {
+        LOGGER.info("Modifying PodTemplates");
         boolean alreadyTracked = trackedPodTemplates.containsKey(uid);
-        boolean hasSlaves = slaves.size() > 0;
-
+        boolean hasSlaves = slaves.size() > 0; // Configmap has podTemplates
         if (alreadyTracked) {
             if (hasSlaves) {
                 // Since the user could have change the immutable image
@@ -155,96 +146,117 @@ public abstract class BaseWatcher {
                 // recreate the PodTemplate altogether. This makes it so
                 // that any changes from within
                 // Jenkins is undone.
-                List<PodTemplate> finalSlaveList = new ArrayList<PodTemplate>();
-                for (PodTemplate podTemplate : trackedPodTemplates.get(uid)) {
-                    String name = podTemplate.getName();
-                    // we allow configmap overrides of maven and nodejs, but not imagestream ones
-                    // as they are less specific/defined wrt podTemplate fields
-                    if (isReservedPodTemplateName(name) && isType.equals(type))
-                        continue;
-                    // for imagestreams, if the core image has not changed, we avoid
-                    // the remove/add pod template churn and multiple imagestream events
-                    // come in for activity that does not affect the pod template
-                    if (type.equals(isType) && JenkinsUtils.hasPodTemplate(podTemplate))
-                        continue;
-                    // once a CM or IS claims a name, it gets to keep it until it is remove or un-labeled
-                    String ret = podTemplateToApiType.putIfAbsent(name, type);
-                    // if not set, or previously set by an obj of the same type
-                    if (ret == null || ret.equals(type)) {
-                        JenkinsUtils.removePodTemplate(podTemplate);
-                        finalSlaveList.add(podTemplate);
-                    } else {
-                        LOGGER.info(String.format(PT_NAME_CLAIMED, type, apiObjName, namespace, name, ret));
-                    }
-                }
 
-                if (finalSlaveList.size() > 0)
-                    trackedPodTemplates.put(uid, finalSlaveList);
-                for (PodTemplate podTemplate : finalSlaveList) {
-                    String name = podTemplate.getName();
-                    // still do put here in case this is a new item from the last 
-                    // update on this CM/IS
-                    podTemplateToApiType.put(name, type);
-                    JenkinsUtils.addPodTemplate(podTemplate);
+                // Check if there are new PodTemplates added or removed to the configmap,
+                // if they are, add them to or remove them from trackedPodTemplates
+                List<PodTemplate> podTemplatesToTrack = new ArrayList<PodTemplate>();
+                purgeTemplates(type, uid, apiObjName, namespace);
+                for(PodTemplate pt: slaves){
+                    podTemplatesToTrack = onlyTrackPodTemplate(type,apiObjName,namespace,podTemplatesToTrack, pt);
+                }
+                updateTrackedPodTemplatesMap(uid, podTemplatesToTrack);
+                for (PodTemplate podTemplate : podTemplatesToTrack) {
+                      // still do put here in case this is a new item from the last
+                      // update on this ConfigMap/ImageStream
+                      addPodTemplate(type,null,null,null, podTemplate);
                 }
             } else {
                 // The user modified the configMap to no longer be a
                 // jenkins-slave.
-                for (PodTemplate podTemplate : trackedPodTemplates.get(uid)) {
-                    String name = podTemplate.getName();
-                    String t = podTemplateToApiType.get(name);
-                    // we should not have included any pod templates we did not
-                    // mark the type for, but we'll check just in case
-                    if (t != null && t.equals(type)) {                            
-                        podTemplateToApiType.remove(name);
-                        JenkinsUtils.removePodTemplate(podTemplate);
-                    } else {
-                        LOGGER.info(String.format(PT_NOT_OWNED, type, apiObjName, namespace, name, t));
-                    }
-                }
-
-                trackedPodTemplates.remove(uid);
+                purgeTemplates(type, uid, apiObjName, namespace);
             }
         } else {
             if (hasSlaves) {
-                // The user modified the api obj to be a jenkins-slave
                 List<PodTemplate> finalSlaveList = new ArrayList<PodTemplate>();
                 for (PodTemplate podTemplate : slaves) {
-                    String name = podTemplate.getName();
-                    // we allow configmap overrides of maven and nodejs, but not imagestream ones
-                    // as they are less specific/defined wrt podTemplate fields
-                    if (isReservedPodTemplateName(name) && isType.equals(type))
-                        continue;
-                    String ret = podTemplateToApiType.putIfAbsent(name, type);
-                    if (ret == null || ret.equals(type)) {
-                        JenkinsUtils.addPodTemplate(podTemplate);
-                        finalSlaveList.add(podTemplate);
-                    } else {
-                        LOGGER.info(String.format(PT_NAME_CLAIMED, type, apiObjName, namespace, name, ret));
-                    }
+                  // The user modified the api obj to be a jenkins-slave
+                  addPodTemplate(type, apiObjName, namespace, finalSlaveList, podTemplate);
                 }
-                if (finalSlaveList.size() > 0)
-                    trackedPodTemplates.put(uid, finalSlaveList);
+                updateTrackedPodTemplatesMap(uid, finalSlaveList);
             }
         }
-    }
-    
-    protected void processSlavesForDeleteEvent(List<PodTemplate> slaves, String type, String uid, String apiObjName, String namespace) {
-        if (!trackedPodTemplates.containsKey(uid))
-            return;
-        for (PodTemplate podTemplate : trackedPodTemplates.get(uid)) {
-            String name = podTemplate.getName();
-            String t = podTemplateToApiType.get(name);
-            // should not need to check this but just in case
-            if (t != null && t.equals(type)) {
-                podTemplateToApiType.remove(name);
-                JenkinsUtils.removePodTemplate(podTemplate);
-            } else {
-                LOGGER.info(String.format(PT_NOT_OWNED, type, apiObjName, namespace, name, t));
-            }
-        }
-        trackedPodTemplates.remove(uid);
-        
     }
 
+    private void purgeTemplates(String type, String uid, String apiObjName, String namespace) {
+        LOGGER.info("Purging PodTemplates for from Configmap with Uid "+uid);
+        for (PodTemplate podTemplate : trackedPodTemplates.get(uid)) {
+            // we should not have included any pod templates we did not
+            // mark the type for, but we'll check just in case
+            removePodTemplate(type, apiObjName, namespace, podTemplate);
+        }
+        trackedPodTemplates.remove(uid);
+    }
+
+    private void updateTrackedPodTemplatesMap(String uid, List<PodTemplate> finalSlaveList) {
+        if (finalSlaveList != null && finalSlaveList.size() > 0)
+            trackedPodTemplates.put(uid, finalSlaveList);
+    }
+
+    // Adds PodTemplate to the List<PodTemplate> correspoding to the ConfigMap of given uid
+    private void trackPodTemplates(String uid, List<PodTemplate> podTemplatesToTrack) {
+        trackedPodTemplates.put(uid, podTemplatesToTrack);
+    }
+
+    // Adds PodTemplate to the List<PodTemplate> correspoding to the ConfigMap of given uid and Deletes from Jenkins
+    private List<PodTemplate> onlyTrackPodTemplate(String type, String apiObjName, String namespace, List<PodTemplate> podTemplates, PodTemplate podTemplate) {
+        String name = podTemplate.getName();
+        // we allow configmap overrides of maven and nodejs, but not imagestream ones
+        // as they are less specific/defined wrt podTemplate fields
+        if (isReservedPodTemplateName(name) && isType.equals(type))
+          return null;
+        // for imagestreams, if the core image has not changed, we avoid
+        // the remove/add pod template churn and multiple imagestream events
+        // come in for activity that does not affect the pod template
+        if (type.equals(isType) && JenkinsUtils.hasPodTemplate(podTemplate))
+          return null;
+        // once a CM or IS claims a name, it gets to keep it until it is remove or un-labeled
+        String ret = podTemplateToApiType.putIfAbsent(name, type);
+        // if not set, or previously set by an obj of the same type
+        if (ret == null || ret.equals(type)) {
+            JenkinsUtils.removePodTemplate(podTemplate);
+            podTemplates.add(podTemplate);
+        } else {
+            LOGGER.info(String.format(PT_NAME_CLAIMED, type, apiObjName, namespace, name, ret));
+        }
+        return podTemplates;
+    }
+
+    // Adds PodTemplate from Jenkins
+    private void addPodTemplate(String type, String apiObjName, String namespace, List<PodTemplate> podTemplates, PodTemplate podTemplate) {
+        String name = podTemplate.getName();
+        // we allow configmap overrides of maven and nodejs, but not imagestream ones
+        // as they are less specific/defined wrt podTemplate fields
+        if (apiObjName != null && namespace != null && podTemplates != null){
+            if (isReservedPodTemplateName(name) && isType.equals(type))
+                return;
+            String ret = podTemplateToApiType.putIfAbsent(name, type);
+            if (ret == null || ret.equals(type)) {
+                JenkinsUtils.addPodTemplate(podTemplate);
+                podTemplates.add(podTemplate);
+            } else {
+                LOGGER.info(String.format(PT_NAME_CLAIMED, type, apiObjName, namespace, name, ret));
+            }
+        } else {
+            podTemplateToApiType.put(name, type);
+            JenkinsUtils.addPodTemplate(podTemplate);
+        }
+    }
+
+    // Delete a PodTemplate from Jenkins
+    private void removePodTemplate(String type, String apiObjName, String namespace, PodTemplate podTemplate) {
+        String name = podTemplate.getName();
+        String t = podTemplateToApiType.get(name);
+        if (t != null && t.equals(type)) {
+            podTemplateToApiType.remove(name);
+            JenkinsUtils.removePodTemplate(podTemplate);
+        } else {
+            LOGGER.info(String.format(PT_NOT_OWNED, type, apiObjName, namespace, name, t));
+        }
+    }
+
+    protected void processSlavesForDeleteEvent(List<PodTemplate> slaves, String type, String uid, String apiObjName, String namespace) {
+        if (trackedPodTemplates.containsKey(uid)) {
+            purgeTemplates(type, uid, apiObjName, namespace);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes the issues taking place below.
Also deals with code refactor.

## Description of problem:

With reference to doc[1], a user can define a configmap with label role: jenkins-slave with kubernetes plugin data.

Now, when the configmap is populated using `oc create -f <file>`, it works fine. however, if any update is done to the configmap using `oc apply -f <file>` then the updated part is not reflected in Jenkins configuration.

[1] - https://docs.openshift.com/container-platform/3.11/using_images/other_images/jenkins.html#configuring-the-jenkins-kubernetes-plug-in

Version-Release number of selected component (if applicable):

OCP 3.11 

## How reproducible:

Always

### Steps to Reproduce:
1. oc create -f v1.yaml --save-config=true
2. oc get -oyaml cm jenkins-slave > v2.yaml
3. vi v2.yaml (#Add new kubernetes pod template)
4. oc apply -f v2.yaml 

### Actual results:

`oc apply` command does not update the configmap.

### Expected results:

Updates are handled in Jenkins configuration using `oc apply` command too.

### Additional info:

However, when I run the following steps in continuation, the new pod template is reflected as expected:

1. oc delete cm jenkins-slave
2. oc create -f v2.yaml --save-config=true

## REMARKS:

1. The `oc apply` command correctly updates the configmap resource.
2. But the apply command does not reflect the actual value of configmap in Jenkins configuration.
3. The very same yaml file when used with `oc create` command, creates the right configuration as expected.

## WORKAROUND:

1. To delete existing configmap and create the intended configmap from scratch to get it reflected as expected in Jenkins configuration.