### PR TITLE
Synchronize branch name from job to bc

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -15,22 +15,17 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
-import hudson.plugins.git.BranchSpec;
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.SubmoduleConfig;
-import hudson.plugins.git.UserRemoteConfig;
-import hudson.plugins.git.extensions.GitSCMExtension;
-import hudson.scm.SCM;
-import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigSpec;
-import io.fabric8.openshift.api.model.BuildSource;
-import io.fabric8.openshift.api.model.BuildStrategy;
-import io.fabric8.openshift.api.model.GitBuildSource;
-import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
+import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
+import static java.util.logging.Level.INFO;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
-import jenkins.branch.Branch;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
@@ -40,251 +35,232 @@ import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static io.fabric8.jenkins.openshiftsync.CredentialsUtils.updateSourceCredentials;
-import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.scm.SCM;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigSpec;
+import io.fabric8.openshift.api.model.BuildSource;
+import io.fabric8.openshift.api.model.BuildStrategy;
+import io.fabric8.openshift.api.model.GitBuildSource;
+import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
+import jenkins.branch.Branch;
 
 public class BuildConfigToJobMapper {
-	public static final String JENKINS_PIPELINE_BUILD_STRATEGY = "JenkinsPipeline";
-	public static final String DEFAULT_JENKINS_FILEPATH = "Jenkinsfile";
-	private static final Logger LOGGER = Logger.getLogger(BuildConfigToJobMapper.class.getName());
+    public static final String JENKINS_PIPELINE_BUILD_STRATEGY = "JenkinsPipeline";
+    public static final String DEFAULT_JENKINS_FILEPATH = "Jenkinsfile";
+    private static final Logger LOGGER = Logger.getLogger(BuildConfigToJobMapper.class.getName());
+    private static final String GIT_SCM_TYPE = "Git";
 
-	public static FlowDefinition mapBuildConfigToFlow(BuildConfig bc) throws IOException {
-		if (!OpenShiftUtils.isPipelineStrategyBuildConfig(bc)) {
-			return null;
-		}
-
-		BuildConfigSpec spec = bc.getSpec();
-		BuildSource source = null;
-		String jenkinsfile = null;
-		String jenkinsfilePath = null;
-    ObjectMeta buildConfigMetadata = bc.getMetadata();
-    if (buildConfigMetadata != null){
-      String buildConfigName = buildConfigMetadata.getName();
-      LOGGER.info("Mapping BuildConfig " + buildConfigName + " to FlowDefinition");
-    }
-		if (spec != null) {
-			source = spec.getSource();
-			BuildStrategy strategy = spec.getStrategy();
-			if (strategy != null) {
-				JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
-				if (jenkinsPipelineStrategy != null) {
-					jenkinsfile = jenkinsPipelineStrategy.getJenkinsfile();
-					jenkinsfilePath = jenkinsPipelineStrategy.getJenkinsfilePath();
-				}
-			}
-		}
-		if (jenkinsfile == null) {
-			// Is this a Jenkinsfile from Git SCM?
-			if (source != null && source.getGit() != null && source.getGit().getUri() != null) {
-				if (jenkinsfilePath == null) {
-					jenkinsfilePath = DEFAULT_JENKINS_FILEPATH;
-				}
-				if (!isEmpty(source.getContextDir())) {
-					jenkinsfilePath = new File(source.getContextDir(), jenkinsfilePath).getPath();
-				}
-				GitSCM gitSCM = getGitSCM(bc);
-				return new CpsScmFlowDefinition(gitSCM, jenkinsfilePath);
-			} else {
-				LOGGER.warning("BuildConfig does not contain source repository information - "
-						+ "cannot map BuildConfig to Jenkins job");
-				return null;
-			}
-		} else {
-			return new CpsFlowDefinition(jenkinsfile, true);
-		}
-	}
-
-	private static GitSCM getGitSCM(BuildConfig bc){
-	  if (bc != null){
-	    BuildSource source = bc.getSpec().getSource();
-	    if (source != null){
-        GitBuildSource gitSource = source.getGit();
-        String branchRef = gitSource.getRef();
-        String gitUrl = gitSource.getUri();
-        List<BranchSpec> branchSpecs = Collections.emptyList();
-        String credentialsId = null;
-        LocalObjectReference sourceSecret = source.getSourceSecret();
-        if (sourceSecret != null){
-          try{
-            credentialsId = updateSourceCredentials(bc);
-          } catch (Exception e){
-            LOGGER.warning("Encountered "+e+" during updateSourceCredentials()");
-          }
-        }
-        if (isNotBlank(branchRef)) {
-          branchSpecs = Collections.singletonList(new BranchSpec(branchRef));
-        }
-        UserRemoteConfig userRemoteConfig = new UserRemoteConfig(gitUrl, null, branchRef, credentialsId);
-        // if credentialsID is null, go with an SCM where anonymous has to be sufficient
-        List userRemoteList = Collections.singletonList(userRemoteConfig);
-        List SubmoduleList = Collections.<GitSCMExtension>emptyList();
-        List GitSCMExtensionList = Collections.<GitSCMExtension>emptyList();
-        GitSCM gitSCM = new GitSCM(userRemoteList, branchSpecs, false, SubmoduleList, null, null, GitSCMExtensionList);
-
-        return gitSCM;
-      }
-    }
-    return null;
-  }
-
-	/**
-	 * Updates the {@link BuildConfig} if the Jenkins {@link WorkflowJob} changes
-   *
-	 * @param job
-	 *            the job thats been updated via Jenkins
-	 * @param buildConfig
-	 *            the OpenShift BuildConfig to update
-	 * @return true if the BuildConfig was changed
-   * This will be decided if the Definition in the Job is of type CpsFlowDefinition or CpsScmFlowDefinition
-   *
-	 */
-	public static boolean updateBuildConfigFromJob(WorkflowJob job, BuildConfig buildConfig) {
-    NamespaceName namespaceName = NamespaceName.create(buildConfig);
-    JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = null;
-    BuildConfigSpec spec = buildConfig.getSpec();
-    if (spec != null) {
-      BuildStrategy strategy = spec.getStrategy();
-      if (strategy != null) {
-        jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
-      }
-    }
-
-    if (jenkinsPipelineStrategy == null) {
-      LOGGER.warning("No jenkinsPipelineStrategy available in the BuildConfig " + namespaceName);
-      return false;
-    }
-
-    LOGGER.info("Updating BuildConfig From Job " + namespaceName);
-
-    FlowDefinition definition = job.getDefinition();
-    String jenkinsfilePath = jenkinsPipelineStrategy.getJenkinsfilePath();
-    if (definition instanceof CpsScmFlowDefinition) {
-      BuildSource source = getOrCreateBuildSource(spec);
-      CpsScmFlowDefinition cpsScmFlowDefinition = (CpsScmFlowDefinition) definition;
-      String scriptPath = cpsScmFlowDefinition.getScriptPath();
-      SCM scm = cpsScmFlowDefinition.getScm();
-      if (scm instanceof GitSCM){
-        GitSCM gitSCM = (GitSCM) scm;
-        List<UserRemoteConfig> userRemoteConfigs = gitSCM.getUserRemoteConfigs();
-        LocalObjectReference sourceSecret = source.getSourceSecret();
-        if  (sourceSecret != null){
-          String sourceSecretName = sourceSecret.getName();
-          UserRemoteConfig sourceSecretUserRemoteConfig = new UserRemoteConfig(null, null,null, sourceSecretName);
-          if (!userRemoteConfigs.contains(sourceSecretUserRemoteConfig)){
-            LOGGER.info("Adding Build SourceSecret " + sourceSecretName + " as UserRemoteConfig");
-            userRemoteConfigs.add(sourceSecretUserRemoteConfig);
-          }
-        }
-      }
-      if (scriptPath != null && scriptPath.trim().length() > 0) {
-        boolean rc = false;
-        String bcContextDir = source.getContextDir();
-        if (StringUtils.isNotBlank(bcContextDir) && scriptPath.startsWith(bcContextDir)) {
-          scriptPath = scriptPath.replaceFirst("^" + bcContextDir + "/?", "");
+    /**
+     * @param bc A BuildConfig object.
+     * @return the FlowDefinition representing a Jenkins Build built from a
+     *         pipeline.
+     */
+    public static FlowDefinition mapBuildConfigToFlow(BuildConfig bc) throws IOException {
+        if (!OpenShiftUtils.isPipelineStrategyBuildConfig(bc)) {
+            return null;
         }
 
-        if (!scriptPath.equals(jenkinsfilePath)) {
-          LOGGER.log(Level.FINE,
-            "updating bc " + namespaceName + " jenkinsfile path to " + scriptPath + " from ");
-          rc = true;
-          jenkinsPipelineStrategy.setJenkinsfilePath(scriptPath);
-        }
-
-        scm = cpsScmFlowDefinition.getScm();
-        if (scm instanceof GitSCM) {
-          populateFromGitSCM(buildConfig, source, (GitSCM) scm, null);
-          LOGGER.log(Level.FINE, "updating bc " + namespaceName);
-          rc = true;
-        }
-        return rc;
-      }
-      return false;
-    }
-
-    if (definition instanceof CpsFlowDefinition) {
-      CpsFlowDefinition cpsFlowDefinition = (CpsFlowDefinition) definition;
-      String jenkinsFileFromDefinition = cpsFlowDefinition.getScript();
-      String jenkinsFileFromStrategy = jenkinsPipelineStrategy.getJenkinsfile();
-      if (jenkinsFileFromDefinition != null && jenkinsFileFromDefinition.trim().length() > 0
-        && !jenkinsFileFromDefinition.equals(jenkinsFileFromStrategy)) {
-        LOGGER.log(Level.FINE, "updating bc " + namespaceName + " jenkinsfile to " + jenkinsFileFromDefinition
-          + " where old jenkinsfile was " + jenkinsFileFromStrategy);
-        jenkinsPipelineStrategy.setJenkinsfile(jenkinsFileFromDefinition);
-        return true;
-      }
-
-      return false;
-    }
-
-    // support multi-branch or github organization jobs
-    BranchJobProperty property = job.getProperty(BranchJobProperty.class);
-    if (property != null) {
-      Branch branch = property.getBranch();
-      if (branch != null) {
-        String ref = branch.getName();
-        SCM scm = branch.getScm();
-        BuildSource source = getOrCreateBuildSource(spec);
-        if (scm instanceof GitSCM) {
-          if (populateFromGitSCM(buildConfig, source, (GitSCM) scm, ref)) {
-            if (StringUtils.isEmpty(jenkinsfilePath)) {
-              jenkinsPipelineStrategy.setJenkinsfilePath("Jenkinsfile");
+        BuildSource source = null;
+        String jenkinsfile = null;
+        String jenkinsfilePath = null;
+        BuildConfigSpec spec = bc.getSpec();
+        if (spec != null) {
+            source = spec.getSource();
+            BuildStrategy strategy = spec.getStrategy();
+            if (strategy != null) {
+                JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+                if (jenkinsPipelineStrategy != null) {
+                    jenkinsfile = jenkinsPipelineStrategy.getJenkinsfile();
+                    jenkinsfilePath = jenkinsPipelineStrategy.getJenkinsfilePath();
+                }
             }
-            return true;
-          }
         }
-      }
+        if (jenkinsfile == null) {
+            // Is this a Jenkinsfile from Git SCM?
+            if (source != null && source.getGit() != null && source.getGit().getUri() != null) {
+                if (jenkinsfilePath == null) {
+                    jenkinsfilePath = DEFAULT_JENKINS_FILEPATH;
+                }
+                if (!isEmpty(source.getContextDir())) {
+                    jenkinsfilePath = new File(source.getContextDir(), jenkinsfilePath).getPath();
+                }
+                GitBuildSource gitSource = source.getGit();
+                String branchRef = gitSource.getRef();
+                List<BranchSpec> branchSpecs = Collections.emptyList();
+                if (isNotBlank(branchRef)) {
+                    branchSpecs = Collections.singletonList(new BranchSpec(branchRef));
+                }
+                String credentialsId = updateSourceCredentials(bc);
+                // if credentialsID is null, go with an SCM where anonymous has to be sufficient
+                UserRemoteConfig remoteConfig = new UserRemoteConfig(gitSource.getUri(), null, null, credentialsId);
+                List<UserRemoteConfig> userRemoteConfigs = Collections.singletonList(remoteConfig);
+                List<SubmoduleConfig> submoduleCfg = Collections.<SubmoduleConfig>emptyList();
+                List<GitSCMExtension> extensions = Collections.<GitSCMExtension>emptyList();
+                GitSCM scm = new GitSCM(userRemoteConfigs, branchSpecs, false, submoduleCfg, null, null, extensions);
+                return new CpsScmFlowDefinition(scm, jenkinsfilePath);
+            } else {
+                LOGGER.warning("BuildConfig does not contain source repository: cannot map BuildConfig to Jenkins job");
+                return null;
+            }
+        } else {
+            return new CpsFlowDefinition(jenkinsfile, true);
+        }
     }
 
-    LOGGER.warning("Cannot update BuildConfig " + namespaceName + " as the definition is of class "
-      + (definition == null ? "null" : definition.getClass().getName()));
-    return false;
-  }
+    /**
+     * Updates the {@link BuildConfig} if the Jenkins {@link WorkflowJob} changes
+     *
+     * @param job         the job thats been updated via Jenkins
+     * @param buildConfig the OpenShift BuildConfig to update
+     * @return true if the BuildConfig was changed This will be decided if the
+     *         Definition in the Job is of type CpsFlowDefinition or
+     *         CpsScmFlowDefinition
+     *
+     */
+    public static boolean updateBuildConfigFromJob(WorkflowJob job, BuildConfig buildConfig) {
+        NamespaceName namespaceName = NamespaceName.create(buildConfig);
+        JenkinsPipelineBuildStrategy jenkinsPipelineStrategy = null;
+        BuildConfigSpec spec = buildConfig.getSpec();
+        if (spec != null) {
+            BuildStrategy strategy = spec.getStrategy();
+            if (strategy != null) {
+                jenkinsPipelineStrategy = strategy.getJenkinsPipelineStrategy();
+            }
+        }
 
-	private static boolean populateFromGitSCM(BuildConfig buildConfig, BuildSource source, GitSCM gitSCM, String ref) {
-		source.setType("Git");
-		List<RemoteConfig> repositories = gitSCM.getRepositories();
-		if (repositories != null && repositories.size() > 0) {
-			RemoteConfig remoteConfig = repositories.get(0);
-			List<URIish> urIs = remoteConfig.getURIs();
-			if (urIs != null && urIs.size() > 0) {
-				URIish urIish = urIs.get(0);
-				String gitUrl = urIish.toString();
-				if (gitUrl != null && gitUrl.length() > 0) {
-					if (StringUtils.isEmpty(ref)) {
-						List<BranchSpec> branches = gitSCM.getBranches();
-						if (branches != null && branches.size() > 0) {
-							BranchSpec branchSpec = branches.get(0);
-							String branch = branchSpec.getName();
-							while (branch.startsWith("*") || branch.startsWith("/")) {
-								branch = branch.substring(1);
-							}
-							if (!branch.isEmpty()) {
-								ref = branch;
-							}
-						}
-					}
-					OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+        if (jenkinsPipelineStrategy == null) {
+            LOGGER.warning("No jenkinsPipelineStrategy available in the BuildConfig " + namespaceName);
+            return false;
+        }
 
-	private static BuildSource getOrCreateBuildSource(BuildConfigSpec spec) {
-		BuildSource source = spec.getSource();
-		if (source == null) {
-			source = new BuildSource();
-			spec.setSource(source);
-		}
-		return source;
-	}
+        FlowDefinition definition = job.getDefinition();
+        if (definition instanceof CpsScmFlowDefinition) {
+            return updateScmFlowDefinition(buildConfig, namespaceName, jenkinsPipelineStrategy, definition);
+        }
+
+        if (definition instanceof CpsFlowDefinition) {
+            return updateCpsFlowDefinition(namespaceName, jenkinsPipelineStrategy, definition);
+        }
+
+        return updateBranchName(job, buildConfig, namespaceName, jenkinsPipelineStrategy, definition);
+    }
+
+    private static boolean updateBranchName(WorkflowJob job, BuildConfig buildConfig, NamespaceName namespaceName,
+            JenkinsPipelineBuildStrategy jenkinsPipelineStrategy, FlowDefinition definition) {
+        // support multi-branch or github organization jobs
+        BranchJobProperty property = job.getProperty(BranchJobProperty.class);
+        if (property != null) {
+            Branch branch = property.getBranch();
+            if (branch != null) {
+                String ref = branch.getName();
+                SCM scm = branch.getScm();
+                BuildConfigSpec spec = buildConfig.getSpec();
+                BuildSource source = getOrCreateBuildSource(spec);
+                buildConfig.getSpec().getSource().getGit().setRef(ref);
+                if (scm instanceof GitSCM) {
+                    if (populateFromGitSCM(buildConfig, source, (GitSCM) scm, ref)) {
+                        if (StringUtils.isEmpty(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+                            jenkinsPipelineStrategy.setJenkinsfilePath("Jenkinsfile");
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        String clazz = (definition == null) ? "null" : definition.getClass().getName();
+        LOGGER.warning("Cannot update BuildConfig " + namespaceName + " as the definition is of class " + clazz);
+        return false;
+    }
+
+    private static boolean updateCpsFlowDefinition(NamespaceName namespaceName,
+            JenkinsPipelineBuildStrategy jenkinsPipelineStrategy, FlowDefinition definition) {
+        CpsFlowDefinition cpsFlowDefinition = (CpsFlowDefinition) definition;
+        String jenkinsfile = cpsFlowDefinition.getScript();
+        if (jenkinsfile != null && jenkinsfile.trim().length() > 0
+                && !jenkinsfile.equals(jenkinsPipelineStrategy.getJenkinsfile())) {
+            LOGGER.log(INFO, "updating bc " + namespaceName + " jenkinsfile to " + jenkinsfile
+                    + " where old jenkinsfile was " + jenkinsPipelineStrategy.getJenkinsfile());
+            jenkinsPipelineStrategy.setJenkinsfile(jenkinsfile);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean updateScmFlowDefinition(BuildConfig buildConfig, NamespaceName namespaceName,
+            JenkinsPipelineBuildStrategy jenkinsPipelineStrategy, FlowDefinition definition) {
+        CpsScmFlowDefinition cpsScmFlowDefinition = (CpsScmFlowDefinition) definition;
+        String scriptPath = cpsScmFlowDefinition.getScriptPath();
+        if (scriptPath != null && scriptPath.trim().length() > 0) {
+            boolean rc = false;
+            BuildConfigSpec spec = buildConfig.getSpec();
+            BuildSource source = getOrCreateBuildSource(spec);
+            String bcContextDir = source.getContextDir();
+            if (StringUtils.isNotBlank(bcContextDir) && scriptPath.startsWith(bcContextDir)) {
+                scriptPath = scriptPath.replaceFirst("^" + bcContextDir + "/?", "");
+            }
+            if (!scriptPath.equals(jenkinsPipelineStrategy.getJenkinsfilePath())) {
+                LOGGER.log(INFO, "updating bc " + namespaceName + " jenkinsfile path to " + scriptPath + " from ");
+                rc = true;
+                jenkinsPipelineStrategy.setJenkinsfilePath(scriptPath);
+            }
+            SCM scm = cpsScmFlowDefinition.getScm();
+            if (scm instanceof GitSCM) {
+                populateFromGitSCM(buildConfig, source, (GitSCM) scm, null);
+                LOGGER.log(INFO, "updating bc " + namespaceName);
+                rc = true;
+            }
+            return rc;
+        }
+        return false;
+    }
+
+    private static boolean populateFromGitSCM(BuildConfig buildConfig, BuildSource source, GitSCM gitSCM, String ref) {
+        LOGGER.info("Populating SCM from BuildConfig " + buildConfig + " for branch: " + ref);
+        source.setType(GIT_SCM_TYPE);
+        List<RemoteConfig> repositories = gitSCM.getRepositories();
+        if (repositories != null && repositories.size() > 0) {
+            if (repositories.size() > 1) {
+                LOGGER.warning("Configuration contains more than 1 repos: OpenShift Sync only support single repo.");
+            }
+            RemoteConfig remote = repositories.get(0);
+            List<URIish> urIs = remote.getURIs();
+            if (urIs != null && urIs.size() > 0) {
+                URIish urIish = urIs.get(0);
+                String gitUrl = urIish.toString();
+                if (gitUrl != null && gitUrl.length() > 0) {
+                    if (StringUtils.isEmpty(ref)) {
+                        List<BranchSpec> branches = gitSCM.getBranches();
+                        if (branches != null && branches.size() > 0) {
+                            BranchSpec branchSpec = branches.get(0);
+                            String branch = branchSpec.getName();
+                            while (branch.startsWith("*") || branch.startsWith("/")) {
+                                branch = branch.substring(1);
+                            }
+                            if (!branch.isEmpty()) {
+                                ref = branch;
+                            }
+                        }
+                    }
+                    OpenShiftUtils.updateGitSourceUrl(buildConfig, gitUrl, ref);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static BuildSource getOrCreateBuildSource(BuildConfigSpec spec) {
+        BuildSource source = spec.getSource();
+        if (source == null) {
+            source = new BuildSource();
+            spec.setSource(source);
+        }
+        return source;
+    }
 }


### PR DESCRIPTION
- Format using 4 spaces instead of tabs. Hence the large commit
- The 2 main changes:
  -                 buildConfig.getSpec().getSource().getGit().setRef(ref);
  -                return false line 192 was missing: https://github.com/openshift/jenkins-sync-plugin/pull/364/files#diff-fbc124cdb4f21738ce080e4247a0a6fbR192
  - splitting updateBuildConfigFromJob into smaller methods
