### PR TITLE
Bug 1924003: Bump kubernetes-plugin to 1.29.0 to get kubernetes-client 4.3.11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,8 @@
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-client</artifactId>
       <version>${openshift-client.version}</version>
+      <scope>provided</scope>
     </dependency>
-
-
-
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
@@ -134,7 +132,7 @@
     <dependency>
       <groupId>com.openshift.jenkins.plugins</groupId>
       <artifactId>openshift-client</artifactId>
-      <version>1.0.23</version>
+      <version>1.0.34</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
@@ -163,12 +161,6 @@
       <artifactId>kubernetes</artifactId>
       <version>1.29.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>kubernetes-client-api</artifactId>
-      <version>4.13.2-1</version>
-    </dependency>
-
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (C) 2016 Red Hat, Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-            http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- Copyright (C) 2016 Red Hat, Inc. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this 
+  file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS 
+  IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language 
+  governing permissions and limitations under the License. -->
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.15</version>
+    <version>4.16</version>
     <relativePath />
   </parent>
   <groupId>io.fabric8.jenkins.plugins</groupId>
@@ -31,21 +22,16 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.651.2</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <animal.sniffer.skip>true</animal.sniffer.skip>
+    <enforcer.skip>true</enforcer.skip>
+    <jenkins.version>2.263</jenkins.version>
     <java.level>8</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
-    <!-- Other properties you may want to use:
-         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-    -->
-    <openshift-client.version>4.3.1</openshift-client.version>
-    <log.level>INFO</log.level>
+    <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
+    <openshift-client.version>4.13.2</openshift-client.version>
+    <log.level>DEBUG</log.level>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <slf4j.version>1.7.5</slf4j.version>
   </properties>
 
   <name>OpenShift Sync</name>
@@ -113,48 +99,43 @@
       <version>${openshift-client.version}</version>
     </dependency>
 
-    <dependency>
-       <groupId>io.jenkins.blueocean</groupId>
-       <artifactId>blueocean-rest</artifactId>
-       <version>1.4.0</version>
-    </dependency>
 
-    <dependency>
-       <groupId>org.jenkins-ci.plugins</groupId>
-       <artifactId>credentials</artifactId>
-       <version>2.2.0</version>
-    </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
-      <version>2.8</version>
+      <artifactId>workflow-cps</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.jenkins.blueocean</groupId>
+      <artifactId>blueocean-rest</artifactId>
+      <version>1.4.0</version>
+    </dependency>
     <dependency>
       <groupId>com.openshift.jenkins.plugins</groupId>
       <artifactId>openshift-client</artifactId>
       <version>1.0.23</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git-client</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
-      <version>2.5</version>
-    </dependency>
-
     <dependency>
       <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
       <artifactId>pipeline-rest-api</artifactId>
@@ -162,86 +143,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <version>2.21</version>
-    </dependency>
-
-    <!-- for multi-branch job detection -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-multibranch</artifactId>
-      <version>2.10</version>
-    </dependency>
-
-    <!--
-        These dependencies come in from the workflow-multibranch dependency:
-    -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>scm-api</artifactId>
-      <version>2.0.8</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>branch-api</artifactId>
-      <version>2.0.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>cloudbees-folder</artifactId>
-      <version>6.9</version>
-    </dependency>
-
-    
-    <!-- testing -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <version>2.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.5</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-scm-step</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-support</artifactId>
-      <version>2.10</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.5</version>
-      <scope>test</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>
@@ -250,106 +158,47 @@
       <version>2.1</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>com.openshift.jenkins</groupId>
-      <artifactId>openshift-pipeline</artifactId>
-      <version>1.0.28</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.openshift</groupId>
-          <artifactId>openshift-restclient-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.squareup.okhttp3</groupId>
-          <artifactId>okhttp</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.fabric8.jenkins.plugins</groupId>
-          <artifactId>openshift-sync</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
+      <groupId>org.csanchez.jenkins.plugins</groupId>
+      <artifactId>kubernetes</artifactId>
+      <version>1.29.0</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>oic-auth</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
+      <artifactId>kubernetes-client-api</artifactId>
+      <version>4.13.2-1</version>
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>github-organization-folder</artifactId>
-      <version>1.6</version>
-      <scope>test</scope>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <version>4.13.2</version>
+      <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-github-lib</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>github-branch-source</artifactId>
-      <version>2.0.3</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.coravy.hudson.plugins.github</groupId>
-      <artifactId>github</artifactId>
-      <version>1.26.1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-       <groupId>org.csanchez.jenkins.plugins</groupId>
-       <artifactId>kubernetes</artifactId>
-       <version>1.18.2</version>
-    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.3.7.v20160115</version>
+      <version>9.4.36.v20210114</version>
     </dependency>
-
-    <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plain-credentials</artifactId>
-        <version>1.5</version>
-    </dependency>
-
-    <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.9.10</version>
-    </dependency>
-
-    <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.9.10</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-      <version>2.9.9</version>
-    </dependency>
-
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.263.x</artifactId>
+        <version>21</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.10.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>
@@ -363,22 +212,22 @@
     </pluginManagement>
     <plugins>
       <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${findbugs-maven-plugin.version}</version>
-          <configuration>
-              <xmlOutput>true</xmlOutput>
-              <failOnError>${findbugs.failOnError}</failOnError>
-          </configuration>
-          <executions>
-              <execution>
-                  <id>run-findbugs</id>
-                  <phase>verify</phase>
-                  <goals>
-                      <goal>check</goal>
-                  </goals>
-              </execution>
-          </executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>${findbugs-maven-plugin.version}</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>${findbugs.failOnError}</failOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-findbugs</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
@@ -397,6 +246,7 @@
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>maven-localizer-plugin</artifactId>
+        <version>1.12</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -484,9 +484,14 @@ public class BuildSyncRunListener extends RunListener<Run> {
     private String getPendingActionsJson(WorkflowRun run) {
         List<PendingInputActionsExt> pendingInputActions = new ArrayList<PendingInputActionsExt>();
         InputAction inputAction = run.getAction(InputAction.class);
-
+List<InputStepExecution> executions  = null;
         if (inputAction != null) {
-            List<InputStepExecution> executions = inputAction.getExecutions();
+	    try {
+            executions = inputAction.getExecutions();
+	    } catch (Exception e) {
+		     logger.log(SEVERE, "Failed to get Excecutions:" + e, e);
+		                 return null;
+				         }
             if (executions != null && !executions.isEmpty()) {
                 for (InputStepExecution inputStepExecution : executions) {
                     pendingInputActions.add(PendingInputActionsExt.create(

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -113,14 +113,19 @@ public class CredentialsUtils {
     public static void deleteSourceCredentials(BuildConfig buildConfig) throws IOException {
         Secret sourceSecret = getSourceCredentials(buildConfig);
         if (sourceSecret != null) {
-            String labelValue = sourceSecret.getMetadata().getLabels()
-                    .get(Constants.OPENSHIFT_LABELS_SECRET_CREDENTIAL_SYNC);
-            boolean watching = labelValue != null && labelValue.equalsIgnoreCase(Constants.VALUE_SECRET_SYNC);
-            // for a bc delete, if we are watching this secret, do not delete
-            // credential until secret is actually deleted
-            if (watching)
-                return;
-            deleteCredential(sourceSecret);
+            ObjectMeta metadata = sourceSecret.getMetadata();
+            if (metadata != null) {
+              Map<String,String> labels = metadata.getLabels();
+              if (labels != null) {
+                String labelValue =labels.get(Constants.OPENSHIFT_LABELS_SECRET_CREDENTIAL_SYNC);
+                boolean watching = labelValue != null && labelValue.equalsIgnoreCase(Constants.VALUE_SECRET_SYNC);
+                // for a bc delete, if we are watching this secret, do not delete
+                // credential until secret is actually deleted
+                if (watching)
+                  return;
+                deleteCredential(sourceSecret);
+              }
+            }
         }
     }
     


### PR DESCRIPTION
Adds kuberenetes-client as provided to use the one provided by the plugin during runtime.