### PR TITLE
Bug 1981957: various fixes on top of v1.0.47 to satisfy regression testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # This Dockerfile is intended for use by openshift/ci-operator config files defined
 # in openshift/release for v4.x prow based PR CI jobs
 
-FROM quay.io/openshift/origin-jenkins-agent-maven:v4.0 AS builder
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.9.0 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-sync-plugin
 COPY . .
 USER 0
 RUN export PATH=/opt/rh/rh-maven35/root/usr/bin:$PATH && mvn clean package
 
-FROM quay.io/openshift/origin-jenkins:v4.0
+FROM quay.io/openshift/origin-jenkins:4.9.0
 RUN rm /opt/openshift/plugins/openshift-sync.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/target/openshift-sync.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-sync.hpi /opt/openshift/plugins/openshift-sync.jpi
+COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/PR-Testing/download-dependencies.sh /usr/local/bin
+RUN /usr/local/bin/download-dependencies.sh

--- a/PR-Testing/Dockerfile-jenkins-test-new-plugin
+++ b/PR-Testing/Dockerfile-jenkins-test-new-plugin
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-2-centos7:v3.11
+FROM quay.io/openshift/origin-jenkins:latest
 USER root
 COPY download-dependencies.sh /usr/local/bin
 COPY ./jpi /opt/openshift/plugins

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -22,7 +22,6 @@ public class Annotations {
 	public static final String GENERATED_BY = "jenkins.openshift.io/generated-by";
 	public static final String GENERATED_BY_JENKINS = "jenkins";
 	public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
-	public static final String BUILDCONFIG_NAME = "openshift.io/build-config.name";
 	public static final String SECRET_NAME = "jenkins.openshift.io/secret.name";
 	public static final String AUTOSTART = "jenkins.openshift.io/autostart";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
@@ -76,6 +76,7 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
             LOGGER.info("BuildConfig informer received add event for: {}" + name);
             try {
                 BuildConfigManager.upsertJob(obj);
+                BuildManager.flushBuildsWithNoBCList();
             } catch (Exception e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
@@ -92,6 +93,7 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
             LOGGER.info("BuildConfig informer received update event for: {} to: {}" + oldRv + " " + newRv);
             try {
                 BuildConfigManager.modifyEventToJenkinsJob(newObj);
+                BuildManager.flushBuildsWithNoBCList();
             } catch (Exception e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildManager.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildManager.java
@@ -15,17 +15,17 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
-import static io.fabric8.jenkins.openshiftsync.Annotations.BUILDCONFIG_NAME;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfig;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfigNameNamespace;
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
 import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_ANNOTATIONS_BUILD_NUMBER;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_LABELS_BUILD_CONFIG_NAME;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.cancelBuild;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.deleteRun;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.getJobFromBuild;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.handleBuildList;
 import static io.fabric8.jenkins.openshiftsync.JenkinsUtils.triggerJob;
-import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAnnotation;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getLabel;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancellable;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isCancelled;
@@ -313,8 +313,8 @@ public class BuildManager {
                 // object
                 bcUid = ref.getUid().intern();
                 synchronized (bcUid) {
-                    // if entire job already deleted via bc delete, just return
-                    if (getJobFromBuildConfigNameNamespace(getAnnotation(build, BUILDCONFIG_NAME),
+                    // if entire job already deleted via bc delete, just return; NOTE: could just use ref.getName() vs.label
+                    if (getJobFromBuildConfigNameNamespace(getLabel(build, OPENSHIFT_LABELS_BUILD_CONFIG_NAME),
                             build.getMetadata().getNamespace()) == null) {
                         return;
                     }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
@@ -15,15 +15,16 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.CONFIGMAP;
+import static java.util.Collections.singletonMap;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,9 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
         LOGGER.info("Starting cluster wide configMap informer for {} !!" + namespaces);
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory();
-        this.informer = factory.sharedIndexInformerFor(ConfigMap.class, getListIntervalInSeconds());
+        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
+        OperationContext withLabels = new OperationContext().withLabels(labels);
+        this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getListIntervalInSeconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         LOGGER.info("ConfigMap informer started for namespaces: {}" + namespaces);

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
@@ -15,12 +15,17 @@
  */
 package io.fabric8.jenkins.openshiftsync;
 
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.CONFIGMAP;
+import static java.util.Collections.singletonMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +55,9 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
         LOGGER.info("Starting configMap informer for {} !!" + namespace);
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
-        this.informer = factory.sharedIndexInformerFor(ConfigMap.class, getResyncPeriodMilliseconds());
+        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
+        OperationContext withLabels = new OperationContext().withLabels(labels);
+        this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         LOGGER.info("ConfigMap informer started for namespace: {}" + namespace);

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -610,6 +610,17 @@ public class OpenShiftUtils {
         return builder.toString();
     }
 
+    public static String getLabel(HasMetadata resource, String name) {
+      ObjectMeta metadata = resource.getMetadata();
+      if (metadata != null) {
+          Map<String, String> labels = metadata.getLabels();
+          if (labels != null) {
+              return labels.get(name);
+          }
+      }
+      return null;
+    }
+
     public static String getAnnotation(HasMetadata resource, String name) {
         ObjectMeta metadata = resource.getMetadata();
         if (metadata != null) {


### PR DESCRIPTION
This will need https://github.com/openshift/origin/pull/26336 to merge in order for the imagestreamtag pod template test to pass in e2e-aws-jenkins

See https://github.com/openshift/jenkins/pull/1297 for the tl;dr saga of how/why I identified these changes

Unfortunately there are some whitespace editor formating diffs between my editor (intellij) and whatever was last used.  If I am going to end up contributing more often to this repo, I can work with @akram to sort that out.

But in the meantime be sure the view with `?w=1` when looking at the file diffs.

i.e. https://github.com/openshift/jenkins-sync-plugin/pull/389/files?w=1

@openshift/openshift-team-build-api @openshift/team-devtools-jenkins 