### PR TITLE
Bug 1995727: fix tests, code around processing build,buildconfig deletes while PV based Jenkins is down

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildClusterInformer.java
@@ -19,11 +19,7 @@ import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -34,7 +30,6 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildConfig;
 
 public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecyclable {
 
@@ -66,9 +61,7 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
         this.informer = factory.sharedIndexInformerFor(Build.class, getListIntervalInSeconds());
         this.informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("Build informer started for namespace: {}" + namespaces);
-//        BuildList list = getOpenshiftClient().builds().inNamespace(namespace).list();
-//        onInit(list.getItems());
+        LOGGER.info("Build informer started for namespaces: {}" + namespaces);
     }
 
     public void stop() {
@@ -128,17 +121,6 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
                 }
             }
         }
-    }
-
-    private static void onInit(List<Build> list) {
-        Collections.sort(list, BUILD_COMPARATOR);
-        // We need to sort the builds into their build configs so we can
-        // handle build run policies correctly.
-        Map<String, BuildConfig> buildConfigMap = new HashMap<>();
-        Map<BuildConfig, List<Build>> buildConfigBuildMap = new HashMap<>(list.size());
-//        BuildManager.mapBuildToBuildConfigs(list, buildConfigMap, buildConfigBuildMap);
-//        BuildManager.mapBuildsToBuildConfigs(buildConfigBuildMap);
-        BuildManager.reconcileRunsAndBuilds();
     }
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigClusterInformer.java
@@ -19,7 +19,6 @@ import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -57,10 +56,8 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
         this.informer = factory.sharedIndexInformerFor(BuildConfig.class, getListIntervalInSeconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
+        BuildManager.flushBuildsWithNoBCList();
         LOGGER.info("BuildConfig informer started for namespace: {}" + namespaces);
-        // BuildConfigList list =
-        // getOpenshiftClient().buildConfigs().inNamespace(namespace).list();
-        // onInit(list.getItems());
     }
 
     public void stop() {
@@ -128,18 +125,5 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
         }
     }
 
-    private void onInit(List<BuildConfig> list) {
-        for (BuildConfig buildConfig : list) {
-            try {
-                BuildConfigManager.upsertJob(buildConfig);
-            } catch (Exception e) {
-                LOGGER.error("Failed to update job", e);
-            }
-        }
-        // poke the BuildWatcher builds with no BC list and see if we
-        // can create job
-        // runs for premature builds
-        BuildManager.flushBuildsWithNoBCList();
-    }
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
@@ -17,8 +17,6 @@ package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +53,6 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         LOGGER.info("BuildConfig informer started for namespace: {}" + namespace);
-        // BuildConfigList list =
-        // getOpenshiftClient().buildConfigs().inNamespace(namespace).list();
-        // onInit(list.getItems());
     }
 
     public void stop() {
@@ -114,18 +109,5 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
         }
     }
 
-    private void onInit(List<BuildConfig> list) {
-        for (BuildConfig buildConfig : list) {
-            try {
-                BuildConfigManager.upsertJob(buildConfig);
-            } catch (Exception e) {
-                LOGGER.error("Failed to update job", e);
-            }
-        }
-        // poke the BuildWatcher builds with no BC list and see if we
-        // can create job
-        // runs for premature builds
-        BuildManager.flushBuildsWithNoBCList();
-    }
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildInformer.java
@@ -18,10 +18,6 @@ package io.fabric8.jenkins.openshiftsync;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +27,6 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildConfig;
 
 public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable {
 
@@ -64,8 +59,6 @@ public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable 
         this.informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         LOGGER.info("Build informer started for namespace: {}" + namespace);
-//        BuildList list = getOpenshiftClient().builds().inNamespace(namespace).list();
-//        onInit(list.getItems());
     }
 
     public void stop() {
@@ -113,17 +106,6 @@ public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable 
                 e.printStackTrace();
             }
         }
-    }
-
-    private static void onInit(List<Build> list) {
-        Collections.sort(list, BUILD_COMPARATOR);
-        // We need to sort the builds into their build configs so we can
-        // handle build run policies correctly.
-        Map<String, BuildConfig> buildConfigMap = new HashMap<>();
-        Map<BuildConfig, List<Build>> buildConfigBuildMap = new HashMap<>(list.size());
-//        BuildManager.mapBuildToBuildConfigs(list, buildConfigMap, buildConfigBuildMap);
-//        BuildManager.mapBuildsToBuildConfigs(buildConfigBuildMap);
-        BuildManager.reconcileRunsAndBuilds();
     }
 
 }

--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -1088,6 +1088,11 @@ func TestPersistentVolumes(t *testing.T) {
 
 	scaleJenkins(false, ta)
 
+	// make sure jenkins is down
+  ta.t.Log("making sure jenkins is down via http get to jenkins console")
+  rawURICheck("", ta, "Failed connect to")
+  ta.t.Log("http get to jenkins console came back OK")
+
 	for buildName, buildInfo := range buildNameToBuildInfoMap {
 		if buildInfo.number%2 == 0 {
 			err = buildClient.BuildV1().Builds(ta.ns).Delete(context.Background(), buildName, metav1.DeleteOptions{})

--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -335,7 +335,8 @@ func checkPodsForText(podName, searchItem string, ta *testArgs) bool {
 }
 
 func rawURICheck(rawURI string, ta *testArgs, query ...string) {
-	err := wait.PollImmediate(30*time.Second, 5*time.Minute, func() (done bool, err error) {
+	// made this 10 minutes to line up with sync plugin relist interval
+	err := wait.PollImmediate(30*time.Second, 10*time.Minute, func() (done bool, err error) {
 		j := NewRef(ta.t, kubeClient, ta.ns)
 		defer j.DelRawPod()
 		podName, err := j.RawURL(rawURI)


### PR DESCRIPTION
See https://github.com/openshift/release/pull/21048#issuecomment-902019733, https://github.com/openshift/release/pull/21048#issuecomment-902039578, and https://github.com/openshift/release/pull/21048#issuecomment-902105002

summary:  existing e2e-aws-jenkins had a hole in its test for covering deleted builds in between jenkins restart where jenkins uses a PV for its state

/assign @coreydaley 
/assign @akram 