### PR TITLE
fix gofmt/goimports in e2e test files

### DIFF
--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"net/url"
 	"strings"
 	"testing"
@@ -16,6 +15,7 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
/assign @akram 
/assign @coreydaley 

this should have the side benefit of promoting our new e2e image to the CI "stable" imagestream so I can then reference it in openshift/jenkins CI

see https://github.com/openshift/release/pull/22581