### PR TITLE
Bug 2024933: Jenkins fabric8 dependencies update, credentials sync test case 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <enforcer.skip>true</enforcer.skip>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.303.3</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
-    <openshift-client.version>5.4.1</openshift-client.version>
+    <openshift-client.version>5.10.1</openshift-client.version>
     <log.level>DEBUG</log.level>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>
@@ -152,17 +152,17 @@
     <dependency>
       <groupId>org.csanchez.jenkins.plugins</groupId>
       <artifactId>kubernetes</artifactId>
-      <version>1.30.0</version>
+      <version>1.31.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>5.4.1</version>
+      <version>5.10.1-171.vaa0774fb8c20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.12.3</version>
+      <version>2.13.0-230.v59243c64b0a5</version>
     </dependency> 
 
     <dependency>
@@ -176,8 +176,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>26</version>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1036.v9f5a1aba8fab</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
In order to fix the problem with jenkins not syncing things on startup, `fabric8`'s `openshift-client` and `kubernetes-client` dependencies have been updated.

At the same time, `jenkins`'s version has been bumped due to new `kubernetes` plugin version, along with `jenkins`'s bom version.

This PR also contains test case which will check that credentials created before jenkins are correctly synced by it.