### PR TITLE
Bug 2034839: Watch ConfigMap and ImageStream also with the legacy label

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
@@ -16,7 +16,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
-import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUES;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.CONFIGMAP;
 import static java.util.Collections.singletonMap;
@@ -53,8 +53,8 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
         LOGGER.info("Starting cluster wide configMap informer for {} !!" + namespaces);
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory();
-        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
-        OperationContext withLabels = new OperationContext().withLabels(labels);
+        Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
+        OperationContext withLabels = new OperationContext().withLabelsIn(labels);
         this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getListIntervalInSeconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
@@ -16,7 +16,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
-import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUES;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.CONFIGMAP;
 import static java.util.Collections.singletonMap;
@@ -55,8 +55,8 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
         LOGGER.info("Starting configMap informer for {} !!" + namespace);
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
-        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
-        OperationContext withLabels = new OperationContext().withLabels(labels);
+        Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
+        OperationContext withLabels = new OperationContext().withLabelsIn(labels);
         this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -59,7 +59,9 @@ public class Constants {
     public static final String OPENSHIFT_PROJECT_ENV_VAR_NAME = "PROJECT_NAME";
     public static final String OPENSHIFT_PROJECT_FILE = "/run/secrets/kubernetes.io/serviceaccount/namespace";
 
-    public static final String IMAGESTREAM_AGENT_LABEL_VALUE = "jenkins-slave";
+    public static final String IMAGESTREAM_AGENT_LABEL_VALUE =  "jenkins-slave";
+    public static final String IMAGESTREAM_AGENT_ALTERNATE_LABEL_VALUE = "jenkins-agent";
+    protected static final String[] IMAGESTREAM_AGENT_LABEL_VALUES = {IMAGESTREAM_AGENT_LABEL_VALUE, IMAGESTREAM_AGENT_ALTERNATE_LABEL_VALUE};
     public static final String IMAGESTREAM_AGENT_LABEL = "role";
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamClusterInformer.java
@@ -16,7 +16,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
-import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUES;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.IMAGESTREAM_TYPE;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.addAgents;
@@ -62,8 +62,8 @@ public class ImageStreamClusterInformer implements ResourceEventHandler<ImageStr
         LOGGER.info("Starting ImageStream informer for {} !!" + namespaces);
         LOGGER.debug("Listing ImageStream resources");
         SharedInformerFactory factory = getInformerFactory();
-        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
-        OperationContext withLabels = new OperationContext().withLabels(labels);
+        Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
+        OperationContext withLabels = new OperationContext().withLabelsIn(labels);
         this.informer = factory.sharedIndexInformerFor(ImageStream.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamInformer.java
@@ -16,7 +16,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
-import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUES;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getInformerFactory;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.IMAGESTREAM_TYPE;
 import static io.fabric8.jenkins.openshiftsync.PodTemplateUtils.addAgents;
@@ -59,8 +59,8 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
         LOGGER.info("Starting ImageStream informer for {} !!" + namespace);
         LOGGER.debug("Listing ImageStream resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
-        Map<String, String> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUE);
-        OperationContext withLabels = new OperationContext().withLabels(labels);
+        Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
+        OperationContext withLabels = new OperationContext().withLabelsIn(labels);
         this.informer = factory.sharedIndexInformerFor(ImageStream.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PodTemplateUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PodTemplateUtils.java
@@ -2,6 +2,7 @@ package io.fabric8.jenkins.openshiftsync;
 
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL;
 import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_LABEL_VALUE;
+import static io.fabric8.jenkins.openshiftsync.Constants.IMAGESTREAM_AGENT_ALTERNATE_LABEL_VALUE;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getAuthenticatedOpenShiftClient;
 import static java.util.logging.Level.FINE;
 
@@ -423,7 +424,8 @@ public class PodTemplateUtils {
 
     protected static boolean hasSlaveLabelOrAnnotation(Map<String, String> map) {
         return map != null && map.containsKey(IMAGESTREAM_AGENT_LABEL)
-                && map.get(IMAGESTREAM_AGENT_LABEL).equals(IMAGESTREAM_AGENT_LABEL_VALUE);
+                && (map.get(IMAGESTREAM_AGENT_LABEL).equals(IMAGESTREAM_AGENT_LABEL_VALUE) ||
+                        map.get(IMAGESTREAM_AGENT_LABEL).equals(IMAGESTREAM_AGENT_ALTERNATE_LABEL_VALUE));
     }
 
     protected static void addAgents(List<PodTemplate> slaves, String type, String uid, String apiObjName,

--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -237,15 +237,16 @@ func instantiateBuild(ta *testArgs) *buildv1.Build {
 	return waitForBuildSuccess(ta, build)
 }
 
-func podTemplateTest(name string, ta *testArgs) {
+func podTemplateTest(podTemplateName string, ta *testArgs) {
 	bc := &buildv1.BuildConfig{}
-	bc.Name = name
+	bc.Name = strings.ReplaceAll(podTemplateName, ":", ".")
+	pipelineDefinition := strings.ReplaceAll(simplemaven, "POD_TEMPLATE_NAME", podTemplateName)
 	bc.Spec = buildv1.BuildConfigSpec{
 		CommonSpec: buildv1.CommonSpec{
 			Strategy: buildv1.BuildStrategy{
 				Type: buildv1.JenkinsPipelineBuildStrategyType,
 				JenkinsPipelineStrategy: &buildv1.JenkinsPipelineBuildStrategy{
-					Jenkinsfile: simplemaven,
+					Jenkinsfile: pipelineDefinition,
 				},
 			},
 		},
@@ -712,52 +713,73 @@ func TestSecretCredentialSyncAfterStartup(t *testing.T) {
 	credCheck(secret.Name, ta, "secret-to-credential", "c2VjcmV0Y3JlZHN5bmMK")
 }
 
-func TestConfMapPodTemplate(t *testing.T) {
+func TestConfigMapPodTemplate(t *testing.T) {
 	ta := setupThroughJenkinsLaunch(t, nil)
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
-
-	cm := &corev1.ConfigMap{Data: map[string]string{"jenkins-agent": `
-      <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
-        <inheritFrom></inheritFrom>
-        <name>jenkins-agent</name>
-        <instanceCap>2147483647</instanceCap>
-        <idleMinutes>0</idleMinutes>
-        <label>jenkins-agent</label>
-        <serviceAccount>jenkins</serviceAccount>
-        <nodeSelector></nodeSelector>
-        <volumes/>
-        <containers>
-          <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-            <name>jnlp</name>
-            <image>image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-maven:latest</image>
-            <privileged>false</privileged>
-            <alwaysPullImage>false</alwaysPullImage>
-            <workingDir>/tmp</workingDir>
-            <command></command>
-            <args>${computer.jnlpmac} ${computer.name}</args>
-            <ttyEnabled>false</ttyEnabled>
-            <resourceRequestCpu></resourceRequestCpu>
-            <resourceRequestMemory></resourceRequestMemory>
-            <resourceLimitCpu></resourceLimitCpu>
-            <resourceLimitMemory></resourceLimitMemory>
-            <envVars/>
-          </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-        </containers>
-        <envVars/>
-        <annotations/>
-        <imagePullSecrets/>
-        <nodeProperties/>
-      </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
-`}}
-	cm.Labels = map[string]string{"role": "jenkins-slave"}
-	cm.Name = "config-map-with-podtemplate"
-
+	labels := map[string]string{"role": "jenkins-agent"}
+	cmName := "config-map-with-podtemplate"
+	podTemplateName := "jenkins-agent"
+	cm := newPodTemplateConfigMap(cmName, podTemplateName, labels)
 	cm, err := kubeClient.CoreV1().ConfigMaps(ta.ns).Create(context.Background(), cm, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error creating pod template cm: %s", err.Error())
 	}
+	podTemplateTest(podTemplateName, ta)
+}
 
-	podTemplateTest("sync-plugin-configmap-pod-template", ta)
+func TestConfigMapLegacyPodTemplate(t *testing.T) {
+	ta := setupThroughJenkinsLaunch(t, nil)
+	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
+	labels := map[string]string{"role": "jenkins-slave"}
+	cmName := "config-map-with-legacy-podtemplate"
+	podTemplateName := "jenkins-slave"
+	cm := newPodTemplateConfigMap(cmName, podTemplateName, labels)
+	cm, err := kubeClient.CoreV1().ConfigMaps(ta.ns).Create(context.Background(), cm, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating pod template cm: %s", err.Error())
+	}
+	podTemplateTest(podTemplateName, ta)
+}
+
+func newPodTemplateConfigMap(configMapName string, podTemplateName string, templateLabels map[string]string) *corev1.ConfigMap {
+	templateDefinition := `
+	      <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+	        <inheritFrom></inheritFrom>
+	        <name>POD_TEMPLATE_NAME</name>
+	        <instanceCap>2147483647</instanceCap>
+	        <idleMinutes>0</idleMinutes>
+	        <label>POD_TEMPLATE_NAME</label>
+	        <serviceAccount>jenkins</serviceAccount>
+	        <nodeSelector></nodeSelector>
+	        <volumes/>
+	        <containers>
+	          <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+	            <name>jnlp</name>
+	            <image>image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-maven:latest</image>
+	            <privileged>false</privileged>
+	            <alwaysPullImage>false</alwaysPullImage>
+	            <workingDir>/tmp</workingDir>
+	            <command></command>
+	            <args>${computer.jnlpmac} ${computer.name}</args>
+	            <ttyEnabled>false</ttyEnabled>
+	            <resourceRequestCpu></resourceRequestCpu>
+	            <resourceRequestMemory></resourceRequestMemory>
+	            <resourceLimitCpu></resourceLimitCpu>
+	            <resourceLimitMemory></resourceLimitMemory>
+	            <envVars/>
+	          </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+	        </containers>
+	        <envVars/>
+	        <annotations/>
+	        <imagePullSecrets/>
+	        <nodeProperties/>
+	      </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+	`
+	templateDefinition = strings.ReplaceAll(templateDefinition, "POD_TEMPLATE_NAME", podTemplateName)
+	cm := &corev1.ConfigMap{Data: map[string]string{podTemplateName: templateDefinition}}
+	cm.Labels = templateLabels
+	cm.Name = configMapName
+	return cm
 }
 
 func TestImageStreamPodTemplate(t *testing.T) {
@@ -765,7 +787,8 @@ func TestImageStreamPodTemplate(t *testing.T) {
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
 
 	is := &imagev1.ImageStream{}
-	is.Name = "jenkins-agent"
+        podTemplateName := "sync-plugin-imagestream-pod-template"
+	is.Name = podTemplateName
 	is.Labels = map[string]string{"role": "jenkins-slave"}
 	is.Spec.Tags = []imagev1.TagReference{
 		{
@@ -790,7 +813,7 @@ func TestImageStreamPodTemplate(t *testing.T) {
 		t.Fatalf("error creating pod template stream: %s", err.Error())
 	}
 
-	podTemplateTest("sync-plugin-imagestream-pod-template", ta)
+	podTemplateTest(podTemplateName, ta)
 }
 
 func TestImageStreamTagPodTemplate(t *testing.T) {
@@ -798,7 +821,9 @@ func TestImageStreamTagPodTemplate(t *testing.T) {
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
 
 	is := &imagev1.ImageStream{}
-	is.Name = "jenkins-agent"
+        podTemplateName := "sync-plugin-imagestreamtag-pod-template"
+        podTemplateTag := "latest"
+	is.Name = podTemplateName
 	is.Labels = map[string]string{"role": "jenkins-slave"}
 	is.Spec.Tags = []imagev1.TagReference{
 		{
@@ -817,7 +842,7 @@ func TestImageStreamTagPodTemplate(t *testing.T) {
 			Annotations: map[string]string{
 				"role": "jenkins-slave",
 			},
-			Name: "latest",
+			Name: podTemplateTag,
 		},
 	}
 
@@ -825,7 +850,7 @@ func TestImageStreamTagPodTemplate(t *testing.T) {
 		t.Fatalf("error creating pod template stream: %s", err.Error())
 	}
 
-	podTemplateTest("sync-plugin-imagestreamtag-pod-template", ta)
+	podTemplateTest(podTemplateName + ":" + podTemplateTag, ta)
 }
 
 func TestJavaBuilderPodTemplate(t *testing.T) {

--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -40,7 +40,7 @@ const (
           try {
              timeout(time: 20, unit: 'MINUTES') {
         
-                node("jenkins-agent") {
+                node("POD_TEMPLATE_NAME") {
                   sh "mvn --version"
                 }
 


### PR DESCRIPTION
Fixes a regression where watching `ConfigMap` and `ImageStream` was only done on the legacy label.
