### PR TITLE
Fixed improperly formatted logger statements

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildClusterInformer.java
@@ -59,18 +59,18 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
     }
 
     public void start() {
-        LOGGER.info("Starting Build informer for {} !!" + namespaces);
+        LOGGER.info("Starting Build informer for " + namespaces + "!!");
         LOGGER.debug("Listing Build resources");
         SharedInformerFactory factory = getInformerFactory();
         this.informer = factory.sharedIndexInformerFor(Build.class, getListIntervalInSeconds());
         this.informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         reconcileRunsAndBuilds();
-        LOGGER.info("Build informer started for namespaces: {}" + namespaces);
+        LOGGER.info("Build informer started for namespaces: " + namespaces);
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespaces);
+      LOGGER.info("Stopping informer " + namespaces + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -79,13 +79,13 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
 
     @Override
     public void onAdd(Build obj) {
-        LOGGER.debug("Build informer  received add event for: {}" + obj);
+        LOGGER.debug("Build informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String name = metadata.getName();
-                LOGGER.info("Build informer received add event for: {}" + name);
+                LOGGER.info("Build informer received add event for: " + name);
                 try {
                     addEventToJenkinsJobRun(obj);
                 } catch (IOException e) {
@@ -98,14 +98,14 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
 
     @Override
     public void onUpdate(Build oldObj, Build newObj) {
-        LOGGER.debug("Build informer received update event for: {} to: {}" + oldObj + " " + newObj);
+        LOGGER.debug("Build informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             ObjectMeta metadata = oldObj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String oldRv = oldObj.getMetadata().getResourceVersion();
                 String newRv = newObj.getMetadata().getResourceVersion();
-                LOGGER.info("Build informer received update event for: {} to: {}" + oldRv + " " + newRv);
+                LOGGER.info("Build informer received update event for: " + oldRv + " to: " + newRv);
                 modifyEventToJenkinsJobRun(newObj);
             }
         }
@@ -113,7 +113,7 @@ public class BuildClusterInformer implements ResourceEventHandler<Build>, Lifecy
 
     @Override
     public void onDelete(Build obj, boolean deletedFinalStateUnknown) {
-        LOGGER.info("Build informer received delete event for: {}" + obj);
+        LOGGER.info("Build informer received delete event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigClusterInformer.java
@@ -54,7 +54,7 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
     }
 
     public void start() {
-        LOGGER.info("Starting BuildConfig informer for {} !!" + namespaces);
+        LOGGER.info("Starting BuildConfig informer for " + namespaces + "!!");
         LOGGER.debug("listing BuildConfig resources");
         SharedInformerFactory factory = getInformerFactory();
         this.informer = factory.sharedIndexInformerFor(BuildConfig.class, getListIntervalInSeconds());
@@ -62,11 +62,11 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
         factory.startAllRegisteredInformers();
         reconcileJobsAndBuildConfigs();
         BuildManager.flushBuildsWithNoBCList();
-        LOGGER.info("BuildConfig informer started for namespace: {}" + namespaces);
+        LOGGER.info("BuildConfig informer started for namespace: " + namespaces);
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespaces);
+      LOGGER.info("Stopping informer " + namespaces + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -75,14 +75,14 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
 
     @Override
     public void onAdd(BuildConfig obj) {
-        LOGGER.debug("BuildConfig informer  received add event for: {}" + obj);
+        LOGGER.debug("BuildConfig informer  received add event for: " + obj);
 
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String name = metadata.getName();
-                LOGGER.info("BuildConfig informer received add event for: {}" + name);
+                LOGGER.info("BuildConfig informer received add event for: " + name);
                 try {
                     upsertJob(obj);
                 } catch (Exception e) {
@@ -95,14 +95,14 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
 
     @Override
     public void onUpdate(BuildConfig oldObj, BuildConfig newObj) {
-        LOGGER.debug("BuildConfig informer received update event for: {} to: {}" + oldObj + " " + newObj);
+        LOGGER.debug("BuildConfig informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             ObjectMeta metadata = oldObj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String oldRv = oldObj.getMetadata().getResourceVersion();
                 String newRv = newObj.getMetadata().getResourceVersion();
-                LOGGER.info("BuildConfig informer received update event for: {} to: {}" + oldRv + " " + newRv);
+                LOGGER.info("BuildConfig informer received update event for: " + oldRv + " to: " + newRv);
                 try {
                     modifyEventToJenkinsJob(newObj);
                 } catch (Exception e) {
@@ -115,7 +115,7 @@ public class BuildConfigClusterInformer implements ResourceEventHandler<BuildCon
 
     @Override
     public void onDelete(BuildConfig obj, boolean deletedFinalStateUnknown) {
-        LOGGER.info("BuildConfig informer received delete event for: {}" + obj);
+        LOGGER.info("BuildConfig informer received delete event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigInformer.java
@@ -50,18 +50,18 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
     }
 
     public void start() {
-        LOGGER.info("Starting BuildConfig informer for {} !!" + namespace);
+        LOGGER.info("Starting BuildConfig informer for " + namespace + "!!");
         LOGGER.debug("listing BuildConfig resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
         this.informer = factory.sharedIndexInformerFor(BuildConfig.class, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         reconcileJobsAndBuildConfigs();
-        LOGGER.info("BuildConfig informer started for namespace: {}" + namespace);
+        LOGGER.info("BuildConfig informer started for namespace: " + namespace);
     }
 
     public void stop() {
-        LOGGER.info("Stopping informer {} !!" + namespace);
+        LOGGER.info("Stopping informer " + namespace + "!!");
         if( this.informer != null ) {
           this.informer.stop();
         }
@@ -69,11 +69,11 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
 
     @Override
     public void onAdd(BuildConfig obj) {
-        LOGGER.debug("BuildConfig informer  received add event for: {}" + obj);
+        LOGGER.debug("BuildConfig informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String name = metadata.getName();
-            LOGGER.info("BuildConfig informer received add event for: {}" + name);
+            LOGGER.info("BuildConfig informer received add event for: " + name);
             try {
                 upsertJob(obj);
                 BuildManager.flushBuildsWithNoBCList();
@@ -86,11 +86,11 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
 
     @Override
     public void onUpdate(BuildConfig oldObj, BuildConfig newObj) {
-        LOGGER.debug("BuildConfig informer received update event for: {} to: {}" + oldObj + " " + newObj);
+        LOGGER.debug("BuildConfig informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             String oldRv = oldObj.getMetadata().getResourceVersion();
             String newRv = newObj.getMetadata().getResourceVersion();
-            LOGGER.info("BuildConfig informer received update event for: {} to: {}" + oldRv + " " + newRv);
+            LOGGER.info("BuildConfig informer received update event for: " + oldRv + " to: " + newRv);
             try {
                 modifyEventToJenkinsJob(newObj);
                 BuildManager.flushBuildsWithNoBCList();
@@ -103,7 +103,7 @@ public class BuildConfigInformer implements ResourceEventHandler<BuildConfig>, L
 
     @Override
     public void onDelete(BuildConfig obj, boolean deletedFinalStateUnknown) {
-        LOGGER.info("BuildConfig informer received delete event for: {}" + obj);
+        LOGGER.info("BuildConfig informer received delete event for: " + obj);
         if (obj != null) {
             try {
                 deleteEventToJenkinsJob(obj);

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildInformer.java
@@ -57,18 +57,18 @@ public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable 
     }
 
     public void start() {
-        LOGGER.info("Starting Build informer for {} !!" + namespace);
+        LOGGER.info("Starting Build informer for " + namespace + "!!");
         LOGGER.debug("Listing Build resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
         this.informer = factory.sharedIndexInformerFor(Build.class, getResyncPeriodMilliseconds());
         this.informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
         reconcileRunsAndBuilds();
-        LOGGER.info("Build informer started for namespace: {}" + namespace);
+        LOGGER.info("Build informer started for namespace: " + namespace);
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespace);
+      LOGGER.info("Stopping informer " + namespace + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -76,7 +76,7 @@ public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable 
 
     @Override
     public void onAdd(Build obj) {
-        LOGGER.debug("Build informer  received add event for: {}" + obj);
+        LOGGER.debug("Build informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String name = metadata.getName();
@@ -92,7 +92,7 @@ public class BuildInformer implements ResourceEventHandler<Build>, Lifecyclable 
 
     @Override
     public void onUpdate(Build oldObj, Build newObj) {
-        LOGGER.debug("Build informer received update event for: {} to: {}" + oldObj + " " + newObj);
+        LOGGER.debug("Build informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             String oldRv = oldObj.getMetadata().getResourceVersion();
             String newRv = newObj.getMetadata().getResourceVersion();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapClusterInformer.java
@@ -50,7 +50,7 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
     }
 
     public void start() {
-        LOGGER.info("Starting cluster wide configMap informer for {} !!" + namespaces);
+        LOGGER.info("Starting cluster wide configMap informer for " + namespaces + "!!");
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory();
         Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
@@ -58,13 +58,13 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
         this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getListIntervalInSeconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("ConfigMap informer started for namespaces: {}" + namespaces);
+        LOGGER.info("ConfigMap informer started for namespaces: " + namespaces);
 //        ConfigMapList list = getOpenshiftClient().configMaps().inNamespace(namespace).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespaces);
+      LOGGER.info("Stopping informer " + namespaces + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -72,13 +72,13 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
 
     @Override
     public void onAdd(ConfigMap obj) {
-        LOGGER.debug("ConfigMap informer received add event for: {}" + obj);
+        LOGGER.debug("ConfigMap informer received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String name = metadata.getName();
-                LOGGER.info("ConfigMap informer received add event for: {}" + name);
+                LOGGER.info("ConfigMap informer received add event for: " + name);
                 List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(obj);
                 String uid = metadata.getUid();
                 PodTemplateUtils.addAgents(podTemplates, CONFIGMAP, uid, name, namespace);
@@ -90,7 +90,7 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
 
     @Override
     public void onUpdate(ConfigMap oldObj, ConfigMap newObj) {
-        LOGGER.debug("ConfigMap informer  received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.debug("ConfigMap informer  received update event for: " + oldObj + " to: " + newObj);
         if (oldObj != null) {
             ObjectMeta oldMetadata = oldObj.getMetadata();
             String namespace = oldMetadata.getNamespace();
@@ -98,7 +98,7 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
                 String oldRv = oldMetadata != null ? oldMetadata.getResourceVersion() : null;
                 ObjectMeta newMetadata = newObj.getMetadata();
                 String newResourceVersion = newMetadata != null ? newMetadata.getResourceVersion() : null;
-                LOGGER.info("Update event received resource versions: {} to: {}" + oldRv + newResourceVersion);
+                LOGGER.info("Update event received resource versions: " + oldRv + " to: " + newResourceVersion);
                 List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(newObj);
                 ObjectMeta metadata = newMetadata;
                 String uid = metadata.getUid();
@@ -113,7 +113,7 @@ public class ConfigMapClusterInformer implements ResourceEventHandler<ConfigMap>
 
     @Override
     public void onDelete(ConfigMap obj, boolean deletedFinalStateUnknown) {
-        LOGGER.debug("ConfigMap informer received delete event for: {}" + obj);
+        LOGGER.debug("ConfigMap informer received delete event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
@@ -53,7 +53,7 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
     }
 
     public void start() {
-        LOGGER.info("Starting configMap informer for {} !!" + namespace);
+        LOGGER.info("Starting configMap informer for " + namespace + "!!");
         LOGGER.debug("listing ConfigMap resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
         Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
@@ -61,13 +61,13 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
         this.informer = factory.sharedIndexInformerFor(ConfigMap.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("ConfigMap informer started for namespace: {}" + namespace);
+        LOGGER.info("ConfigMap informer started for namespace: " + namespace);
 //        ConfigMapList list = getOpenshiftClient().configMaps().inNamespace(namespace).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespace);
+      LOGGER.info("Stopping informer " + namespace + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -76,11 +76,11 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
 
     @Override
     public void onAdd(ConfigMap obj) {
-        LOGGER.debug("ConfigMap informer  received add event for: {}" + obj);
+        LOGGER.debug("ConfigMap informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String name = metadata.getName();
-            LOGGER.info("ConfigMap informer received add event for: {}" + name);
+            LOGGER.info("ConfigMap informer received add event for: " + name);
             List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(obj);
             String uid = metadata.getUid();
             String namespace = metadata.getNamespace();
@@ -90,14 +90,14 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
 
     @Override
     public void onUpdate(ConfigMap oldObj, ConfigMap newObj) {
-        LOGGER.debug("ConfigMap informer  received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.debug("ConfigMap informer  received update event for: " + oldObj + " to: " + newObj);
         if (oldObj != null) {
             String oldResourceVersion = oldObj.getMetadata() != null ? oldObj.getMetadata().getResourceVersion() : null;
             String newResourceVersion = newObj.getMetadata() != null ? newObj.getMetadata().getResourceVersion() : null;
             // fabric8 will call onUpdate on re-list even if nothing changed.
             // This is to prevent constantly purging pod templates when there are no changes
             if (!Objects.equals(oldResourceVersion, newResourceVersion)) {
-                LOGGER.info("Update event received resource versions: {} to: {}" + oldResourceVersion + newResourceVersion);
+                LOGGER.info("Update event received resource versions: " + oldResourceVersion + " to: " + newResourceVersion);
                 List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(newObj);
                 ObjectMeta metadata = newObj.getMetadata();
                 String uid = metadata.getUid();
@@ -111,7 +111,7 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
 
     @Override
     public void onDelete(ConfigMap obj, boolean deletedFinalStateUnknown) {
-        LOGGER.debug("ConfigMap informer received delete event for: {}" + obj);
+        LOGGER.debug("ConfigMap informer received delete event for: " + obj);
         if (obj != null) {
             List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(obj);
             ObjectMeta metadata = obj.getMetadata();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfigurationTimerTask.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfigurationTimerTask.java
@@ -125,9 +125,9 @@ public class GlobalPluginConfigurationTimerTask extends SafeTimerTask {
         logger.info("Stopping all informers ...");
         synchronized (this) {
             for (Lifecyclable informer : informers) {
-                logger.info("Stopping informer: {}" + informer);
+                logger.info("Stopping informer: " + informer);
                 informer.stop();
-                logger.info("Stopped informer: {}" + informer);
+                logger.info("Stopped informer: " + informer);
             }
             informers.clear();
             logger.info("Stopped all informers");

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamClusterInformer.java
@@ -59,7 +59,7 @@ public class ImageStreamClusterInformer implements ResourceEventHandler<ImageStr
     }
 
     public void start() {
-        LOGGER.info("Starting ImageStream informer for {} !!" + namespaces);
+        LOGGER.info("Starting ImageStream informer for " + namespaces + "!!");
         LOGGER.debug("Listing ImageStream resources");
         SharedInformerFactory factory = getInformerFactory();
         Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
@@ -67,26 +67,26 @@ public class ImageStreamClusterInformer implements ResourceEventHandler<ImageStr
         this.informer = factory.sharedIndexInformerFor(ImageStream.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("ImageStream informer started for namespace: {}" + namespaces);
+        LOGGER.info("ImageStream informer started for namespace: " + namespaces);
 //        ImageStreamList list = getOpenshiftClient().imageStreams().inNamespace(namespace).withLabels(labels).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-        LOGGER.info("Stopping secret informer {} !!" + namespaces);
+        LOGGER.info("Stopping secret informer " + namespaces + "!!");
         this.informer.stop();
     }
 
     @Override
     public void onAdd(ImageStream obj) {
-        LOGGER.debug("ImageStream informer  received add event for: {}" + obj);
+        LOGGER.debug("ImageStream informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String name = metadata.getName();
                 String uid = metadata.getUid();
-                LOGGER.info("ImageStream informer received add event for: {}" + name);
+                LOGGER.info("ImageStream informer received add event for: " + name);
                 List<PodTemplate> slaves = PodTemplateUtils.getPodTemplatesListFromImageStreams(obj);
                 addAgents(slaves, IMAGESTREAM_TYPE, uid, name, namespace);
             } else {
@@ -97,7 +97,7 @@ public class ImageStreamClusterInformer implements ResourceEventHandler<ImageStr
 
     @Override
     public void onUpdate(ImageStream oldObj, ImageStream newObj) {
-        LOGGER.info("ImageStream informer received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.info("ImageStream informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             List<PodTemplate> slaves = PodTemplateUtils.getPodTemplatesListFromImageStreams(newObj);
             ObjectMeta metadata = newObj.getMetadata();
@@ -114,7 +114,7 @@ public class ImageStreamClusterInformer implements ResourceEventHandler<ImageStr
 
     @Override
     public void onDelete(ImageStream obj, boolean deletedFinalStateUnknown) {
-        LOGGER.info("ImageStream informer received delete event for: {}" + obj);
+        LOGGER.info("ImageStream informer received delete event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamInformer.java
@@ -56,7 +56,7 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
     }
 
     public void start() {
-        LOGGER.info("Starting ImageStream informer for {} !!" + namespace);
+        LOGGER.info("Starting ImageStream informer for " + namespace + "!!");
         LOGGER.debug("Listing ImageStream resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
         Map<String, String[]> labels = singletonMap(IMAGESTREAM_AGENT_LABEL, IMAGESTREAM_AGENT_LABEL_VALUES);
@@ -64,13 +64,13 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
         this.informer = factory.sharedIndexInformerFor(ImageStream.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("ImageStream informer started for namespace: {}" + namespace);
+        LOGGER.info("ImageStream informer started for namespace: " + namespace);
 //        ImageStreamList list = getOpenshiftClient().imageStreams().inNamespace(namespace).withLabels(labels).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespace);
+      LOGGER.info("Stopping informer " + namespace + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -79,12 +79,12 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
 
     @Override
     public void onAdd(ImageStream obj) {
-        LOGGER.debug("ImageStream informer  received add event for: {}" + obj);
+        LOGGER.debug("ImageStream informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String name = metadata.getName();
             String uid = metadata.getUid();
-            LOGGER.info("ImageStream informer received add event for: {}" + name);
+            LOGGER.info("ImageStream informer received add event for: " + name);
             List<PodTemplate> slaves = PodTemplateUtils.getPodTemplatesListFromImageStreams(obj);
             addAgents(slaves, IMAGESTREAM_TYPE, uid, name, namespace);
         }
@@ -92,7 +92,7 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
 
     @Override
     public void onUpdate(ImageStream oldObj, ImageStream newObj) {
-        LOGGER.info("ImageStream informer received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.info("ImageStream informer received update event for: " + oldObj + " to: " + newObj);
         if (newObj != null) {
             List<PodTemplate> slaves = PodTemplateUtils.getPodTemplatesListFromImageStreams(newObj);
             ObjectMeta metadata = newObj.getMetadata();
@@ -105,7 +105,7 @@ public class ImageStreamInformer implements ResourceEventHandler<ImageStream>, L
 
     @Override
     public void onDelete(ImageStream obj, boolean deletedFinalStateUnknown) {
-        LOGGER.info("ImageStream informer received delete event for: {}" + obj);
+        LOGGER.info("ImageStream informer received delete event for: " + obj);
         if (obj != null) {
             List<PodTemplate> slaves = PodTemplateUtils.getPodTemplatesListFromImageStreams(obj);
             ObjectMeta metadata = obj.getMetadata();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PodTemplateUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PodTemplateUtils.java
@@ -496,7 +496,7 @@ public class PodTemplateUtils {
                 List<PodTemplate> templates = podTemplatesFromConfigMap(configMap);
                 trackedPodTemplates.put(uid, templates);
                 for (PodTemplate podTemplate : templates) {
-                    LOGGER.info("Adding PodTemplate {}" + podTemplate);
+                    LOGGER.info("Adding PodTemplate " + podTemplate);
                     addPodTemplate(podTemplate);
                 }
             }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretClusterInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretClusterInformer.java
@@ -55,7 +55,7 @@ public class SecretClusterInformer implements ResourceEventHandler<Secret>, Life
     }
 
     public void start() {
-        LOGGER.info("Starting cluster wide secret informer {} !!" + namespaces);
+        LOGGER.info("Starting cluster wide secret informer " + namespaces + "!!");
         LOGGER.debug("listing Secret resources");
         SharedInformerFactory factory = getInformerFactory();
         Map<String, String> labels = singletonMap(OPENSHIFT_LABELS_SECRET_CREDENTIAL_SYNC, VALUE_SECRET_SYNC);
@@ -63,13 +63,13 @@ public class SecretClusterInformer implements ResourceEventHandler<Secret>, Life
         this.informer = factory.sharedIndexInformerFor(Secret.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("Secret informer started for namespace: {}" + namespaces);
+        LOGGER.info("Secret informer started for namespace: " + namespaces);
 //        SecretList list = getOpenshiftClient().secrets().inNamespace(namespace).withLabels(labels).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespaces);
+      LOGGER.info("Stopping informer " + namespaces + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -78,13 +78,13 @@ public class SecretClusterInformer implements ResourceEventHandler<Secret>, Life
 
     @Override
     public void onAdd(Secret obj) {
-        LOGGER.debug("Secret informer  received add event for: {}" + obj);
+        LOGGER.debug("Secret informer  received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String namespace = metadata.getNamespace();
             if (namespaces.contains(namespace)) {
                 String name = metadata.getName();
-                LOGGER.info("Secret informer received add event for: {}" + name);
+                LOGGER.info("Secret informer received add event for: " + name);
                 SecretManager.insertOrUpdateCredentialFromSecret(obj);
             } else {
                 LOGGER.debug("Received event for a namespace we are not watching: {} ... ignoring", namespace);
@@ -94,7 +94,7 @@ public class SecretClusterInformer implements ResourceEventHandler<Secret>, Life
 
     @Override
     public void onUpdate(Secret oldObj, Secret newObj) {
-        LOGGER.debug("Secret informer received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.debug("Secret informer received update event for: " + oldObj + " to: " + newObj);
         if (oldObj != null) {
             ObjectMeta metadata = oldObj.getMetadata();
             String namespace = metadata.getNamespace();

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/SecretInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/SecretInformer.java
@@ -52,7 +52,7 @@ public class SecretInformer implements ResourceEventHandler<Secret>, Lifecyclabl
     }
 
     public void start() {
-        LOGGER.info("Starting secret informer {} !!" + namespace);
+        LOGGER.info("Starting secret informer " + namespace + "!!");
         LOGGER.debug("listing Secret resources");
         SharedInformerFactory factory = getInformerFactory().inNamespace(namespace);
         Map<String, String> labels = singletonMap(OPENSHIFT_LABELS_SECRET_CREDENTIAL_SYNC, VALUE_SECRET_SYNC);
@@ -60,14 +60,14 @@ public class SecretInformer implements ResourceEventHandler<Secret>, Lifecyclabl
         this.informer = factory.sharedIndexInformerFor(Secret.class, withLabels, getResyncPeriodMilliseconds());
         informer.addEventHandler(this);
         factory.startAllRegisteredInformers();
-        LOGGER.info("Secret informer started for namespace: {}" + namespace);
+        LOGGER.info("Secret informer started for namespace: " + namespace);
 
 //        SecretList list = getOpenshiftClient().secrets().inNamespace(namespace).withLabels(labels).list();
 //        onInit(list.getItems());
     }
 
     public void stop() {
-      LOGGER.info("Stopping informer {} !!" + namespace);
+      LOGGER.info("Stopping informer " + namespace + "!!");
       if( this.informer != null ) {
         this.informer.stop();
       }
@@ -76,18 +76,18 @@ public class SecretInformer implements ResourceEventHandler<Secret>, Lifecyclabl
 
     @Override
     public void onAdd(Secret obj) {
-        LOGGER.debug("Secret informer  received add event for: {}" + obj);
+        LOGGER.debug("Secret informer received add event for: " + obj);
         if (obj != null) {
             ObjectMeta metadata = obj.getMetadata();
             String name = metadata.getName();
-            LOGGER.info("Secret informer received add event for: {}" + name);
+            LOGGER.info("Secret informer received add event for: " + name);
             SecretManager.insertOrUpdateCredentialFromSecret(obj);
         }
     }
 
     @Override
     public void onUpdate(Secret oldObj, Secret newObj) {
-        LOGGER.debug("Secret informer received update event for: {} to: {}" + oldObj + newObj);
+        LOGGER.debug("Secret informer received update event for: " + oldObj + " to: " + newObj);
         if (oldObj != null) {
             final String name = oldObj.getMetadata().getName();
             LOGGER.info("Secret informer received update event for: {}", name);


### PR DESCRIPTION
In many of the log statements throughout the project there are improperly formatted logger statements that attempt to use placeholders but are actually using concatenation. This makes it quite difficult to read the logs when trying to debug issues. I noticed that many other logger statement are using concatenation so I changed all these statements to concatenation with the proper format.

There were a handful of statements that properly use placeholders so I did not touch those ones.

To test view the log statements and observe that they come out properly formatted without {} showing up in the logs