### PR TITLE
Bug 2064139: Fix configmap update bug that constantly purges templates with no changes

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
@@ -93,14 +94,16 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
         if (oldObj != null) {
             String oldResourceVersion = oldObj.getMetadata() != null ? oldObj.getMetadata().getResourceVersion() : null;
             String newResourceVersion = newObj.getMetadata() != null ? newObj.getMetadata().getResourceVersion() : null;
-            LOGGER.info("Update event received resource versions: {} to: {}" + oldResourceVersion + newResourceVersion);
-            List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(newObj);
-            ObjectMeta metadata = newObj.getMetadata();
-            String uid = metadata.getUid();
-            String name = metadata.getName();
-            String namespace = metadata.getNamespace();
-            LOGGER.info("ConfigMap informer received update event for: {}", name);
-            PodTemplateUtils.updateAgents(podTemplates, CONFIGMAP, uid, name, namespace);
+            if (!Objects.equals(oldResourceVersion, newResourceVersion)) {
+                LOGGER.info("Update event received resource versions: {} to: {}" + oldResourceVersion + newResourceVersion);
+                List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(newObj);
+                ObjectMeta metadata = newObj.getMetadata();
+                String uid = metadata.getUid();
+                String name = metadata.getName();
+                String namespace = metadata.getNamespace();
+                LOGGER.info("ConfigMap informer received update event for: {}", name);
+                PodTemplateUtils.updateAgents(podTemplates, CONFIGMAP, uid, name, namespace);
+            }
         }
     }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapInformer.java
@@ -94,6 +94,8 @@ public class ConfigMapInformer implements ResourceEventHandler<ConfigMap>, Lifec
         if (oldObj != null) {
             String oldResourceVersion = oldObj.getMetadata() != null ? oldObj.getMetadata().getResourceVersion() : null;
             String newResourceVersion = newObj.getMetadata() != null ? newObj.getMetadata().getResourceVersion() : null;
+            // fabric8 will call onUpdate on re-list even if nothing changed.
+            // This is to prevent constantly purging pod templates when there are no changes
             if (!Objects.equals(oldResourceVersion, newResourceVersion)) {
                 LOGGER.info("Update event received resource versions: {} to: {}" + oldResourceVersion + newResourceVersion);
                 List<PodTemplate> podTemplates = PodTemplateUtils.podTemplatesFromConfigMap(newObj);


### PR DESCRIPTION
Our team is experiencing a bug where every 5 minutes (which seems to be the default interval for checking for updates on pod templates) every single pod template gets purged and re-added even if there are no changes to them. This is causing us problems because if a job tries to start during the purging it hangs forever since it cant find the agent. Since its purging them all so often we run into this issue very often.

According to the fabric8 documentation for onUpdate: "It is also called when a re-list happens, and it will get called even if nothing changes." I believe this is why it is happening.

I added a check to see if the versions were the same. This way it will only run the update if there are actually changes. 

To test add a set of configmaps for pod templates and wait 5 minutes and observe that there are no update actions performed on them. Edit one of the pod templates and then observe that only the edited one has been purged and added. 