### PR TITLE
bump from image to latest cpaas image since we no longer replace in CI, no longer are in ocp payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # This Dockerfile is intended for use by openshift/ci-operator config files defined
 # in openshift/release for v4.x prow based PR CI jobs
 
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.9.0 AS builder
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.11.0 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-sync-plugin
 COPY . .
 USER 0
 RUN export PATH=/opt/rh/rh-maven35/root/usr/bin:$PATH && mvn clean package
 
-FROM quay.io/openshift/origin-jenkins:4.9.0
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0
+#FROM quay.io/openshift/origin-jenkins:4.11.0
 RUN rm /opt/openshift/plugins/openshift-sync.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/target/openshift-sync.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-sync.hpi /opt/openshift/plugins/openshift-sync.jpi


### PR DESCRIPTION
ok @coreydaley @akram

first reproduced the sidecar e2e failures from https://github.com/openshift/release/pull/28845#issuecomment-1137207704 locally, then confirmed locally these changes address them.

while I left the quay.io ref as a comment, in folks want to avoid needing registry.redhat.io creds, moving forward, in my opinion, we should be using the latest CPaas images 

I did confirm that `registry.redhat.io/ocp-tools-4/jenkins-rhel8:latest` does not exist though, so unless that changes, we'll need to bump this Dockerfile (and the analogous one that will have to be done in the client repo) periodically as we move to v4.11, v4.12, etc.