### PR TITLE
Bump kubernetes-client-api to 5.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>5.10.1-171.vaa0774fb8c20</version>
+      <version>5.10.2-173.v3f2fe50ae296</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Bumped the kubernetes-client-api to 5.12.2 to remove the vulnerability
Ref: https://github.com/advisories/GHSA-98g7-rxmf-rrxm

Signed-off-by: divyansh42 <diagrawa@redhat.com>