### PR TITLE
Update text of error message that we are looking for

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,7 @@ RUN curl -L -o maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.8.8/binarie
 RUN ./maven/bin/mvn --version && \
 	./maven/bin/mvn clean package
 
-FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.12.0
+FROM registry.ci.openshift.org/origin/4.16:jenkins
 RUN rm /opt/openshift/plugins/openshift-sync.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/target/openshift-sync.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-sync.hpi /opt/openshift/plugins/openshift-sync.jpi
-COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/PR-Testing/download-dependencies.sh /usr/local/bin
-RUN /usr/local/bin/download-dependencies.sh

--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -647,7 +647,7 @@ func TestCreateThenDeleteBC(t *testing.T) {
 		t.Fatalf("error on bc %s delete: %s", bc.Name, err.Error())
 	}
 
-	jobLogCheck(bc.Name, ta, "<body><h2>HTTP ERROR 404 Not Found</h2>")
+	jobLogCheck(bc.Name, ta, "<h2>Not Found</h2>")
 }
 
 func TestSecretCredentialSync(t *testing.T) {
@@ -673,7 +673,7 @@ func TestSecretCredentialSync(t *testing.T) {
 		t.Fatalf("error updating secret: %s", err.Error())
 	}
 
-	credCheck(secret.Name, ta, "<body><h2>HTTP ERROR 404 Not Found</h2>")
+	credCheck(secret.Name, ta, "<h2>Not Found</h2>")
 
 	secret.Labels = map[string]string{"credential.sync.jenkins.openshift.io": "true"}
 	secret, err = kubeClient.CoreV1().Secrets(ta.ns).Update(context.Background(), secret, metav1.UpdateOptions{})
@@ -688,7 +688,7 @@ func TestSecretCredentialSync(t *testing.T) {
 		t.Fatalf("error deleting secret %s: %s", secret.Name, err.Error())
 	}
 
-	credCheck(secret.Name, ta, "<body><h2>HTTP ERROR 404 Not Found</h2>")
+	credCheck(secret.Name, ta, "<h2>Not Found</h2>")
 }
 
 func TestSecretCredentialSyncAfterStartup(t *testing.T) {
@@ -1065,7 +1065,7 @@ func TestDeletedBuildDeletesRun(t *testing.T) {
 	for _, buildInfo := range buildNameToBuildInfoMap {
 		dbg(buildInfo.number)
 		if buildInfo.number%2 == 0 {
-			rawURICheck(buildInfo.jenkinsBuildURI, ta, "<body><h2>HTTP ERROR 404 Not Found</h2>")
+			rawURICheck(buildInfo.jenkinsBuildURI, ta, "<h2>Not Found</h2>")
 		} else {
 			rawURICheck(buildInfo.jenkinsBuildURI, ta, fmt.Sprintf("Build #%d", buildInfo.number))
 		}


### PR DESCRIPTION
It looks like the newer versions of Jenkins changed their 404 error message text which is what we key off of for some of the tests. This test currently doesn't run against the newest jenkins, so it won't pass, the test is also timing out because this plugin is not compatible with the plugins/dependencies that are included in the older jenkins image that this tests against. We are going to have to override the test to get this merged.