### PR TITLE
OCPTOOLS-393: Use development mode for NodeJS Sample

### DIFF
--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -212,7 +212,7 @@ try {
         } // pipeline
 `
 	bluegreenTemplateYAML = `
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   template: bluegreen-pipeline
@@ -227,7 +227,7 @@ metadata:
     tags: instant-app,jenkins
   name: bluegreen-pipeline
 objects:
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     annotations:
@@ -312,7 +312,7 @@ objects:
     database-admin-password: ${DATABASE_ADMIN_PASSWORD}
     database-password: ${DATABASE_PASSWORD}
     database-user: ${DATABASE_USER}
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     name: blue-${NAME}
@@ -321,7 +321,7 @@ objects:
     to:
       kind: Service
       name: ${NAME}-blue
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     name: green-${NAME}
@@ -330,7 +330,7 @@ objects:
     to:
       kind: Service
       name: ${NAME}-green
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     name: ${NAME}
@@ -433,7 +433,7 @@ objects:
           image: ' '
           livenessProbe:
             httpGet:
-              path: /pagecount
+              path: /live
               port: 8080
             initialDelaySeconds: 30
             timeoutSeconds: 3
@@ -442,7 +442,7 @@ objects:
           - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /pagecount
+              path: /ready
               port: 8080
             initialDelaySeconds: 3
             timeoutSeconds: 3

--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -371,6 +371,8 @@ objects:
     strategy:
       sourceStrategy:
         env:
+        - name: NODE_ENV
+          value: development
         - name: NPM_MIRROR
           value: ${NPM_MIRROR}
         from:


### PR DESCRIPTION
Force NodeJS to use the "development" mode when building the blue-green sample application. In OCP 4.16, the Samples Operator upgrades the `latest` tag to version 20, and the s2i builder image defaults the build mode to `production`. NodeJS production mode prunes all test dependencies out of the resulting image, which can significantly reduce overall image size.

Building in `production` mode breaks the BuildConfig deployed by the template because it runs `npm test` in a `postCommit` action/hook. Setting the `NODE_ENV` environment variable to `development` preserves the test dependencies, allowing the node tests to run.

See also: https://issues.redhat.com/browse/NODE-2184