### PR TITLE
change nodejs20 default build environment to developer

### DIFF
--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -373,6 +373,8 @@ objects:
         env:
         - name: NPM_MIRROR
           value: ${NPM_MIRROR}
+        - name: NODE_ENV
+          value: "development"
         from:
           kind: ImageStreamTag
           name: nodejs:latest


### PR DESCRIPTION
NodeJS20 builds in production mode by default the DevDependencies not to be installed. Missing dependencies in trun has been causing the e2e test failures.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED