### PR TITLE
OCPTOOLS-393: Use development mode for NodeJS Sample

### DIFF
--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -371,6 +371,8 @@ objects:
     strategy:
       sourceStrategy:
         env:
+        - name: NODE_ENV
+          value: development
         - name: NPM_MIRROR
           value: ${NPM_MIRROR}
         from:
@@ -431,7 +433,7 @@ objects:
           image: ' '
           livenessProbe:
             httpGet:
-              path: /pagecount
+              path: /live
               port: 8080
             initialDelaySeconds: 30
             timeoutSeconds: 3
@@ -440,7 +442,7 @@ objects:
           - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /pagecount
+              path: /ready
               port: 8080
             initialDelaySeconds: 3
             timeoutSeconds: 3
@@ -510,7 +512,7 @@ objects:
           image: ' '
           livenessProbe:
             httpGet:
-              path: /pagecount
+              path: /live
               port: 8080
             initialDelaySeconds: 30
             timeoutSeconds: 3
@@ -519,7 +521,7 @@ objects:
           - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /pagecount
+              path: /ready
               port: 8080
             initialDelaySeconds: 3
             timeoutSeconds: 3
@@ -612,7 +614,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:${POSTGRESQL_VERSION}
+          name: postgresql:latest
           namespace: ${NAMESPACE}
       type: ImageChange
     - type: ConfigChange


### PR DESCRIPTION
Force NodeJS to use the "development" mode when building the blue-green sample application. In OCP 4.16, the Samples Operator upgrades the `latest` tag to version 20, and the s2i builder image defaults the build mode to `production`. NodeJS production mode prunes all test dependencies out of the resulting image, which can significantly reduce overall image size.

Building in `production` mode breaks the BuildConfig deployed by the template because it runs `npm test` in a `postCommit` action/hook. Setting the `NODE_ENV` environment variable to `development` preserves the test dependencies, allowing the node tests to run.

See also: https://issues.redhat.com/browse/NODE-2184

Also, readiness and liveliness probe are changed to `/ready` and `/live`, since the original repo removed the `/pagecount` route from the app.
 