### PR TITLE
JKNS-573: Update jenkins baseline version from 2.426.2 to 2.504.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:1.20 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-sync-plugin
 COPY . .
 USER 0
-
+# We need a newer maven version as the RHEL package is still on 3.8.5
+RUN microdnf -y install gzip
+RUN curl -L -o maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz && \
+ 	mkdir maven && \
+ 	tar -xvzf maven.tar.gz -C maven --strip-component 1
 # Use the downloaded version of maven to build the package
-RUN mvn --version
-RUN mvn clean package
+RUN ./maven/bin/mvn --version && \
+ 	./maven/bin/mvn clean package
 
 FROM registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.17.0
 RUN rm /opt/openshift/plugins/openshift-sync.jpi

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.77</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
     <groupId>io.fabric8.jenkins.plugins</groupId>
@@ -22,7 +22,7 @@
     <properties>
         <revision>1.1.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.426.2</jenkins.version>
+        <jenkins.version>2.504.2</jenkins.version>
         <log.level>INFO</log.level>
     </properties>
 
@@ -114,48 +114,48 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.426.x -->
+            <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.504.x -->
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.426.x</artifactId>
-                <version>2705.vf5c48c31285b_</version>
+                <artifactId>bom-2.504.x</artifactId>
+                <version>4969.v6ffa_18d90c9f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.12.5</version>
+                <version>2.14.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-multibranch</artifactId>
-                <version>773.vc4fe1378f1d5</version>
+                <version>806.vb_b_688f609ee9</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-support</artifactId>
-                <version>865.v43e78cc44e0d</version>
+                <version>968.v8f17397e87b_8</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
                 <artifactId>pipeline-rest-api</artifactId>
-                <version>2.34</version>
+                <version>2.38</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git</artifactId>
-                <version>5.2.1</version>
+                <version>5.7.0</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.blueocean</groupId>
                 <artifactId>blueocean-rest</artifactId>
-                <version>1.27.9</version>
+                <version>1.27.19</version>
             </dependency>
             <dependency>
                 <groupId>org.csanchez.jenkins.plugins</groupId>
                 <artifactId>kubernetes</artifactId>
-                <version>4174.v4230d0ccd951</version>
+                <version>4353.vb_47977da_9417</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -165,7 +165,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.0</version>
+                <version>2.18.0</version>
                 <configuration>
                     <excludes>
                         <exclude>org.apache.commons:commons-collections4</exclude>
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.2.0</version>
+                <version>4.9.3.1</version>
                 <configuration>
                     <failOnError>false</failOnError>
                 </configuration>
@@ -184,14 +184,14 @@
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs</artifactId>
-                        <version>4.8.3</version>
+                        <version>4.9.3</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.47</version>
+                <version>3.65</version>
                 <configuration>
                     <pluginFirstClassLoader>true</pluginFirstClassLoader>
                     <loggers>
@@ -224,7 +224,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>4.2</version>
+                <version>5.0.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <header>header.txt</header>
@@ -249,7 +249,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>enforce-no-snapshots</id>
@@ -279,7 +279,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -293,7 +293,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.4.1</version>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>enforce-no-snapshots</id>
@@ -316,7 +316,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.11.2</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -329,7 +329,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 
+import hudson.model.Descriptor.FormException;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
@@ -108,7 +109,12 @@ public class BuildConfigToJobMapper {
                 return null;
             }
         } else {
-            return new CpsFlowDefinition(jenkinsfile, true);
+            try {
+                return new CpsFlowDefinition(jenkinsfile, true);
+            } catch (FormException e) {
+                // TODO Auto-generated catch block
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -49,8 +49,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
@@ -86,6 +84,7 @@ import io.jenkins.blueocean.rest.factory.BlueRunFactory;
 import io.jenkins.blueocean.rest.model.BluePipelineNode;
 import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.BlueRun.BlueRunResult;
+import jakarta.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hudson.model.Fingerprint;
+import hudson.model.Descriptor.FormException;
 import hudson.security.ACL;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -485,8 +486,13 @@ public class CredentialsUtils {
             return null;
 
         }
-        return new UsernamePasswordCredentialsImpl(GLOBAL, secretName, secretName,
-                new String(DECODER.decode(usernameData), UTF_8), new String(DECODER.decode(passwordData), UTF_8));
+        try {
+            return new UsernamePasswordCredentialsImpl(GLOBAL, secretName, secretName,
+                    new String(DECODER.decode(usernameData), UTF_8), new String(DECODER.decode(passwordData), UTF_8));
+        } catch (FormException e) {
+            // TODO Auto-generated catch block
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
- [x] Update Jenkins baseline version to 2.504.2

- [x] Update Jenkins bom in dependency management section to 2.504.x release line.

- [x] Remove dependency version overrides as needed.