### PR TITLE
JKNS-629: Replace deprecated Jenkins agent image with latest

### DIFF
--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -823,7 +823,7 @@ func TestImageStreamPodTemplate(t *testing.T) {
 		{
 			From: &corev1.ObjectReference{
 				Kind: "DockerImage",
-				Name: "registry.redhat.io/openshift4/ose-jenkins-agent-maven:v4.10",
+				Name: "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.15.0",
 			},
 			Name: "base",
 		},
@@ -841,7 +841,7 @@ func TestImageStreamPodTemplate(t *testing.T) {
 		t.Fatalf("error creating pod template stream: %s", err.Error())
 	}
 
-	podTemplateTest(podTemplateName, simplemaven1, ta)
+	podTemplateTest(podTemplateName, simpleoc, ta)
 }
 
 func TestImageStreamTagPodTemplate(t *testing.T) {
@@ -857,7 +857,7 @@ func TestImageStreamTagPodTemplate(t *testing.T) {
 		{
 			From: &corev1.ObjectReference{
 				Kind: "DockerImage",
-				Name: "registry.redhat.io/openshift4/ose-jenkins-agent-maven:v4.10",
+				Name: "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.15.0",
 			},
 			Name: "base",
 		},
@@ -877,7 +877,7 @@ func TestImageStreamTagPodTemplate(t *testing.T) {
 		t.Fatalf("error creating pod template stream: %s", err.Error())
 	}
 
-	podTemplateTest(podTemplateName+":"+podTemplateTag, simplemaven1, ta)
+	podTemplateTest(podTemplateName+":"+podTemplateTag, simpleoc, ta)
 }
 
 func TestJavaBuilderPodTemplate(t *testing.T) {

--- a/test/e2e/testobjects.go
+++ b/test/e2e/testobjects.go
@@ -55,12 +55,30 @@ const (
           }
 `
 
+	// simplemaven1 is no longer used in the test, as simpleoc replaces it. It should be removed in the cleanup PR.
 	simplemaven1 = `
          try {
             timeout(time: 20, unit: 'MINUTES') {
 
                node("POD_TEMPLATE_NAME") {
                   sh "mvn --version"
+               }
+
+            }
+         } catch (err) {
+            echo "in catch block"
+            echo "Caught: ${err}"
+            currentBuild.result = 'FAILURE'
+            throw err
+         }
+`
+
+	simpleoc = `
+         try {
+            timeout(time: 20, unit: 'MINUTES') {
+
+               node("POD_TEMPLATE_NAME") {
+                  sh "oc version"
                }
 
             }


### PR DESCRIPTION
- Remove `registry.redhat.io/openshift4/ose-jenkins-agent-maven:v4.10`
- Add `registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.15.0`

Signed-off-by: Vinu K vkochuku@redhat.com