### PR TITLE
JKNS-632: update test validation logic to find text

### DIFF
--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -399,14 +399,12 @@ func rawURICheck(rawURI string, ta *testArgs, query ...string) {
 			ta.t.Logf("got error %s on output for %s", err.Error(), rawURI)
 			return false, nil
 		}
-		found := true
 		for _, q := range query {
-			found = found && checkPodsForText(podName, q, ta)
+			if checkPodsForText(podName, q, ta) {
+				return true, nil
+			}
 		}
-		if !found {
-			return false, nil
-		}
-		return true, nil
+		return false, nil
 	})
 	if err != nil {
 		debugAndFailTest(ta, fmt.Sprintf("unexpected results for %s", rawURI))
@@ -1071,7 +1069,7 @@ func TestDeletedBuildDeletesRun(t *testing.T) {
 		if buildInfo.number%2 == 0 {
 			rawURICheck(buildInfo.jenkinsBuildURI, ta, "<h2>Not Found</h2>")
 		} else {
-			rawURICheck(buildInfo.jenkinsBuildURI, ta, fmt.Sprintf("Build #%d", buildInfo.number))
+			rawURICheck(buildInfo.jenkinsBuildURI, ta, fmt.Sprintf("<h1>#%d", buildInfo.number), fmt.Sprintf("Build #%d", buildInfo.number))
 		}
 	}
 


### PR DESCRIPTION
- [x] update test validation logic to find text

This will fix the `TestDeletedBuildDeletesRun` failure as `Build` keyword is missing in build logs of latest Jenkins LTS version. This will also fix `e2e-aws-jenkins-sync-plugin` CI test of [openshift/jenkins#1878](https://github.com/openshift/jenkins/pull/1878)
