### PR TITLE
JKNS-641: Add JENKINS_AGENT_BASE_IMAGE env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ USER 0
 RUN mvn --version
 RUN mvn clean package
 
-FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.17.0
 RUN rm /opt/openshift/plugins/openshift-sync.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-sync-plugin/target/openshift-sync.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-sync.hpi /opt/openshift/plugins/openshift-sync.jpi

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 
 all: test-e2e
 
-
+# TODO: Need to debug why test pod does not set `JENKINS_AGENT_BASE_IMAGE` enviornment variable
 test-e2e:
 	oc version
 	go version
-	hack/tag-ci-image.sh
+	JENKINS_AGENT_BASE_IMAGE=registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel9:v4.17.0 hack/tag-ci-image.sh
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 75m -v ./test/e2e/...
 
 verify:


### PR DESCRIPTION
- Add `JENKINS_AGENT_BASE_IMAGE` env variable
- This env variable expected to provide latest Jenkins agent base image to test pod in CI infra but it fails as workaround set this variable in Makefile.