### PR TITLE
JKNS-703: Update logic for ConfigMapPodTemplate test cases

### DIFF
--- a/test/e2e/sync_plugin_test.go
+++ b/test/e2e/sync_plugin_test.go
@@ -729,28 +729,32 @@ func TestSecretCredentialSyncAfterStartup(t *testing.T) {
 func TestConfigMapPodTemplate(t *testing.T) {
 	ta := setupThroughJenkinsLaunch(t, nil)
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
-	labels := map[string]string{"role": "jenkins-agent"}
-	cmName := "config-map-with-podtemplate"
 	podTemplateName := "jenkins-agent"
+	// Instead of using a ConfigMap to define the Jenkins PodTemplate, we are leveraging a BuildConfig for now
+	// as a valid mechanism to provisioning PodTemplate.
+	/*labels := map[string]string{"role": "jenkins-agent"}
+	cmName := "config-map-with-podtemplate"
 	cm := newPodTemplateConfigMap(cmName, podTemplateName, labels)
 	cm, err := kubeClient.CoreV1().ConfigMaps(ta.ns).Create(context.Background(), cm, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error creating pod template cm: %s", err.Error())
-	}
+	}*/
 	podTemplateTest(podTemplateName, simplemaven2, ta)
 }
 
 func TestConfigMapLegacyPodTemplate(t *testing.T) {
 	ta := setupThroughJenkinsLaunch(t, nil)
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
-	labels := map[string]string{"role": "jenkins-slave"}
-	cmName := "config-map-with-legacy-podtemplate"
 	podTemplateName := "jenkins-slave"
+	// Instead of using a ConfigMap to define the Jenkins PodTemplate, we are leveraging a BuildConfig for now
+	// as a valid mechanism to provisioning PodTemplate.
+	/* labels := map[string]string{"role": "jenkins-slave"}
+	cmName := "config-map-with-legacy-podtemplate"
 	cm := newPodTemplateConfigMap(cmName, podTemplateName, labels)
 	cm, err := kubeClient.CoreV1().ConfigMaps(ta.ns).Create(context.Background(), cm, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error creating pod template cm: %s", err.Error())
-	}
+	}*/
 	podTemplateTest(podTemplateName, simplemaven2, ta)
 }
 
@@ -811,6 +815,7 @@ func newPodTemplateConfigMap(configMapName string, podTemplateName string, templ
 }
 
 func TestImageStreamPodTemplate(t *testing.T) {
+	t.Skip("Skipping this test as leveraging a BuildConfig as a valid mechanism to provisioning PodTemplate for now")
 	ta := setupThroughJenkinsLaunch(t, nil)
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
 
@@ -844,6 +849,7 @@ func TestImageStreamPodTemplate(t *testing.T) {
 }
 
 func TestImageStreamTagPodTemplate(t *testing.T) {
+	t.Skip("Skipping this test as leveraging a BuildConfig as a valid mechanism to provisioning PodTemplate for now")
 	ta := setupThroughJenkinsLaunch(t, nil)
 	defer projectClient.ProjectV1().Projects().Delete(context.Background(), ta.ns, metav1.DeleteOptions{})
 


### PR DESCRIPTION
- Leverage a BuildConfig for now instead of ConfigMap for PodTemplate
- Skip ImageStreamPodTemplate test cases for now as BuildConfig is valid mechanism to provisioning PodTemplate

RollBack Test changes from - https://github.com/openshift/jenkins-sync-plugin/pull/576